### PR TITLE
Improve i18n

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -128,7 +128,7 @@ class Document_Revisions_Admin {
 			6 => sprintf( __( 'Document published. <a href="%s">Download document</a>', 'wp-document-revisions' ), esc_url( get_permalink($post_ID) ) ),
 			7 => __( 'Document saved.', 'wp-document-revisions' ),
 			8 => sprintf( __( 'Document submitted. <a target="_blank" href="%s">Download document</a>', 'wp-document-revisions' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) ),
-			9 => sprintf( __( 'Document scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview document</a>', 'wp-document-revisions' ), date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post_ID ) ) ),
+			9 => sprintf( __( 'Document scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview document</a>', 'wp-document-revisions' ), date_i18n( sprintf( _x( '%1$s @ %2$s', '%1$s: date; %2$s: time', 'wp-document-revision' ), get_option( 'date_format' ), get_option( 'time_format' ) ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post_ID ) ) ),
 			10 => sprintf( __( 'Document draft updated. <a target="_blank" href="%s">Download document</a>', 'wp-document-revisions' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) ),
 		);
 
@@ -182,11 +182,11 @@ class Document_Revisions_Admin {
 		$help = array(
 			'document' => array(
 				__( 'Basic Usage', 'wp-document-revisions' ) =>
-			    	'<p>' . __( 'This screen allows users to collaboratively edit documents and track their revision history. To begin, enter a title for the document, click <code>Upload New Version</code> and select the file from your computer., 'wp-document-revisions' ) . '</p>' .
-			    	'<p>' . __( 'Once successfully uploaded, you can enter a revision log message, assign the document an author, and describe its current workflow state., 'wp-document-revisions' ) . '</p>' .
+			    	'<p>' . __( 'This screen allows users to collaboratively edit documents and track their revision history. To begin, enter a title for the document, click <code>Upload New Version</code> and select the file from your computer.', 'wp-document-revisions' ) . '</p>' .
+			    	'<p>' . __( 'Once successfully uploaded, you can enter a revision log message, assign the document an author, and describe its current workflow state.', 'wp-document-revisions' ) . '</p>' .
 					'<p>' . __( 'When done, simply click <code>Update</code> to save your changes', 'wp-document-revisions' ) . '</p>',
 				__( 'Revision Log', 'wp-document-revisions' ) =>
-			    	'<p>' . __( 'The revision log provides a short summary of the changes reflected in a particular revision. Used widely in the open-source community, it provides a comprehensive history of the document at a glance., 'wp-document-revisions' ) . '</p>' .
+			    	'<p>' . __( 'The revision log provides a short summary of the changes reflected in a particular revision. Used widely in the open-source community, it provides a comprehensive history of the document at a glance.', 'wp-document-revisions' ) . '</p>' .
 					'<p>' . __( 'You can download and view previous versions of the document by clicking the timestamp in the revision log. You can also restore revisions by clicking the <code>restore</code> button beside the revision.', 'wp-document-revisions' ) . '</p>',
 				__( 'Workflow State', 'wp-document-revisions' ) =>
 			    	'<p>' . __( 'The workflow state field can be used to help team members understand at what stage a document sits within a particular organization&quot;s workflow. The field is optional, and can be customized or queried by clicking <code>Workflow States</code> on the left-hand side.', 'wp-document-revisions' ) . '</p>',
@@ -195,8 +195,8 @@ class Document_Revisions_Admin {
 			),
 			'edit-document' => array(
 				__( 'Documents', 'wp-document-revisions' ) =>
-				    '<p>' . __( 'Below is a list of all documents to which you have access. Click the document title to edit the document or download the latest version., 'wp-document-revisions' ) . '</p>' .
-					'<p>' . __( 'To add a new document, click <strong>Add Document</strong> on the left-hand side., 'wp-document-revisions' ) . '</p>' .
+				    '<p>' . __( 'Below is a list of all documents to which you have access. Click the document title to edit the document or download the latest version.', 'wp-document-revisions' ) . '</p>' .
+					'<p>' . __( 'To add a new document, click <strong>Add Document</strong> on the left-hand side.', 'wp-document-revisions' ) . '</p>' .
 					'<p>' . __( 'To view all documents at a particular workflow state, click <strong>Workflow States</strong> in the menu on the left.', 'wp-document-revisions' ) . '</p>',
 			),
 		);
@@ -211,7 +211,7 @@ class Document_Revisions_Admin {
 		//convert array into string for pre-3.3 compatability
 		$output = '';
 		foreach ( $help[ $screen->id] as $label => $text )
-			$output .= '<h4>' . __( $label, 'wp-document-revisions' ) . '</h4>' . __( $text, 'wp-document-revisions' );
+			$output .= "<h4>{$label}</h4>{$text}";
 
 		return apply_filters( 'document_help', $output, $screen );
 


### PR DESCRIPTION
Hi Ben,

got something for you:
- Split strings at paragraphs, so they are easier to handle by translators (less HTML, no "\n\t")
- No translating variables
- Leverage user settings for date format

Thanks,
Konstantin
