### PR TITLE
Verify the workflow_state is set in post before checking to see if it changed.

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -979,7 +979,7 @@ class Document_Revisions_Admin {
 		$old = wp_get_post_terms( $post_id,  'workflow_state', true );
 
 		//no change, keep moving
-		if ( isset( $old) && $old[0]->term_id == $_POST['workflow_state'] )
+		if ( isset( $old ) && $old[0]->term_id == $_POST['workflow_state'] )
 			return;
 
 		//all's good, let's save


### PR DESCRIPTION
Prevents PHP Debug error thrown by workflow_state_save function when updating a document that doesn't have a workflow state set.
