### PR TITLE
Adding a new document won't have a file attached yet.

### DIFF
--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -369,7 +369,13 @@ class Document_Revisions {
 		if ( get_post_type( $post ) == 'attachment' )
 			$attachment = $post;
 		else if ( get_post_type( $post ) == 'document' )
-				$attachment = get_post( $this->get_latest_revision( $post->ID )->post_content );
+				$latest_revision = $this->get_latest_revision( $post->ID );
+
+				// verify a previous revision exists
+				if ( $latest_revision == false )
+					return false;
+					
+				$attachment = get_post( $latest_revision->post_content );
 
 			//sanity check in case post_content somehow doesn't represent an attachment,
 			// or in case some sort of non-document, non-attachment object/ID was passed


### PR DESCRIPTION
On the Add New Document screen the Document_Revisions->permalink() method is calling the get_file_type() method.  If there isn't a file attached yet, the get_file_type() method should return false.  

I am honestly, not sure if this is the BEST solution, but it is a demonstration of a possible approach.  

Currently the following PHP Debug errors are thrown when on the dashboard Add New Document screen:

> Warning: Cannot modify header information - headers already sent by (output started at /plugins/wp-document-revisions/wp-document-revisions.php:372) in /wp-includes/option.php on line 568
> 
> Notice: Trying to get property of non-object in /plugins/wp-document-revisions/wp-document-revisions.php on line 372 
