### PR TITLE
Allow for standard rss feed for document post type

### DIFF
--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -1096,12 +1096,12 @@ class Document_Revisions {
 		if ( !$this->verify_post_type() )
 			return $default;
 
-		// Look for setting to allow default post type rss feed for documents.  Need to define a settings panel?
-		if ( true )
-			return $default;
-		else
+		// filter to over ride use of the custom doucment feed
+		if ( apply_filters( 'document_custom_feed', true ) )
 			return 'revision_log';
-
+		else
+			return $default;
+			
 	}
 
 
@@ -1115,14 +1115,11 @@ class Document_Revisions {
 		if ( !$this->verify_post_type() )
 			return;
 
-		// Look for setting to allow default post type rss feed for documents. Need to define a settings panel?
-		if ( true )
-			return;
-		else{
+		// filter to over ride use of a validation key
+		if ( apply_filters( 'document_verify_feed_key', true ) ){
 			if ( is_feed() && !$this->validate_feed_key() )
 				wp_die( __( 'Sorry, this is a private feed.', 'wp-document-revisions' ) );
 		}
-
 
 	}
 


### PR DESCRIPTION
The custom revision rss feed is great.  But I have a case where we just want to show the standard custom post type rss feed via the stardard wordpress rss feed:

/feed?post_type=document

I added a simple if statement to two functions that are messing this up: hijack_feed and revision_feed_auth.  Basically, I'd like to add a setting panel for wp document revisions and allow the user to choose the type of rss feed they would like.  These two functions would then look up this setting.  Thoughts?
