### PR TITLE
Saving workflow state

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -979,7 +979,7 @@ class Document_Revisions_Admin {
 		$old = wp_get_post_terms( $post_id,  'workflow_state', true );
 
 		//no change, keep moving
-		if ( isset( $old[0] ) && $old[0]->term_id == $_POST['workflow_state'] )
+		if ( isset( $old[0] ) && $old[0]->slug == $_POST['workflow_state'] )
 			return;
 
 		//all's good, let's save


### PR DESCRIPTION
$_POST['workflow-state'] is a slug, not an id. So compare slugs, not ids. Related to these two issues: [#1](http://wordpress.org/support/topic/unable-to-save-workflow-state-in-wp-351?replies=3) [#2](http://wordpress.org/support/topic/cannot-add-or-edit-workflow-state?replies=1) 

The most recent change invalidates the need for this (it just always updates regardless), but it might be confusing down the road if the comparison is slugs and ids.
