### PR TITLE
Add filter to allow opt-out of WebDAV Edit Document

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -345,7 +345,7 @@ class Document_Revisions_Admin {
 			</div>
 		<?php } ?>
 		<div id="lock_override">
-			<?php if ( $latest_version = $this->get_latest_revision( $post->ID ) ) { ?>
+			<?php if ( $latest_version = $this->get_latest_revision( $post->ID ) && apply_filters( 'document_revisions_enable_webdav', true ) ) { ?>
 			<object id="winFirefoxPlugin" type="application/x-sharepoint" width="0" height="0" style="visibility: hidden;"></object>
 			<a id="edit-desktop-button" href="<?php echo get_permalink( $post->ID ); ?>" class="button" title="<?php esc_attr_e( 'Edit on Desktop', 'wp-document-revisions' ); ?>">
 				<?php _e( 'Edit on Desktop', 'wp-document-revisions' ); ?>


### PR DESCRIPTION
When editing a document in Chrome, without support for WebDAV enabled on the server and without authorizing any plugins to load when in the document admin, I get a "Plug-in Blocked" error every time I load the page.

![screen shot 2014-11-12 at 2 29 06 pm](https://cloud.githubusercontent.com/assets/286171/5019901/4c9b39fc-6a78-11e4-8343-a20131248513.png)

WebDAV seems really cool, but I don't have the bandwidth to figure out how to serve it properly and securely in our current configuration. I think at least parts of this should be opt-in, as not everyone will be WebDAV savvy.

Adding a filter for `document_revisions_enable_webdav` to opt out seems like a straight forward approach. It at least avoids loading the markup, though the JS continues to be available. Happy to discuss others as well.

Great plugin, thanks! :)
