### PR TITLE
[PR] Make tests pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,52 @@
+sudo: false
+
 language: php
 
-php:
-    - 5.3
-    - 5.4
+notifications:
+  email:
+    on_success: never
+    on_failure: change
 
-env:
-    - WP_VERSION=latest WP_MULTISITE=0
-    - WP_VERSION=latest WP_MULTISITE=1
+branches:
+  only:
+    - master
+
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
+
+matrix:
+  include:
+    - php: 7.1
+      env: WP_VERSION=latest
+    - php: 7.0
+      env: WP_VERSION=latest
+    - php: 5.6
+      env: WP_VERSION=latest
+    - php: 5.3
+      env: WP_VERSION=latest
 
 before_script:
-    - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - |
+    if [[ ! -z "$WP_VERSION" ]] ; then
+      bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+      if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then
+        composer global require "phpunit/phpunit=4.8.*"
+      else
+        composer global require "phpunit/phpunit=5.7.*"
+      fi
+    fi
+  - |
+    if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
+      composer global require wp-coding-standards/wpcs
+      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+    fi
 
-script: phpunit
-
-sudo: false
+script:
+  - |
+    if [[ ! -z "$WP_VERSION" ]] ; then
+      phpunit
+      WP_MULTISITE=1 phpunit
+    fi

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 3 ]; then
-	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
 	exit 1
 fi
 
@@ -10,6 +10,7 @@ DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
 
 WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
@@ -24,6 +25,8 @@ download() {
 
 if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
 	WP_TESTS_TAG="tags/$WP_VERSION"
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
 else
 	# http serves a single offer, whereas https serves multiple. we only want one
 	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
@@ -46,14 +49,20 @@ install_wp() {
 
 	mkdir -p $WP_CORE_DIR
 
-	if [ $WP_VERSION == 'latest' ]; then
-		local ARCHIVE_NAME='latest'
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p /tmp/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  /tmp/wordpress-nightly/wordpress-nightly.zip
+		unzip -q /tmp/wordpress-nightly/wordpress-nightly.zip -d /tmp/wordpress-nightly/
+		mv /tmp/wordpress-nightly/wordpress/* $WP_CORE_DIR
 	else
-		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
-
-	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
-	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
 
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
@@ -71,13 +80,14 @@ install_test_suite() {
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
 		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
-
-	cd $WP_TESTS_DIR
 
 	if [ ! -f wp-tests-config.php ]; then
 		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
@@ -87,6 +97,11 @@ install_test_suite() {
 }
 
 install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
 	# parse DB_HOST for port or socket references
 	local PARTS=(${DB_HOST//\:/ })
 	local DB_HOSTNAME=${PARTS[0]};

--- a/includes/HTTP/WebDAV/Server.php
+++ b/includes/HTTP/WebDAV/Server.php
@@ -105,7 +105,7 @@ class HTTP_WebDAV_Server
      *
      * @param void
      */
-    function HTTP_WebDAV_Server()
+    function __construct()
     {
         // PHP messages destroy XML output -> switch them off
         ini_set("display_errors", 0);

--- a/includes/HTTP/WebDAV/Tools/_parse_lockinfo.php
+++ b/includes/HTTP/WebDAV/Tools/_parse_lockinfo.php
@@ -75,7 +75,7 @@ class _parse_lockinfo
 	 * @param  string  path of stream to read
 	 * @access public
 	 */
-    function _parse_lockinfo($path) 
+    function __construct($path)
 	{
 		// we assume success unless problems occur
 		$this->success = true;

--- a/includes/HTTP/WebDAV/Tools/_parse_propfind.php
+++ b/includes/HTTP/WebDAV/Tools/_parse_propfind.php
@@ -59,7 +59,7 @@ class _parse_propfind
 	 *
 	 * @access public
 	 */
-	function _parse_propfind($path) 
+	function __construct($path)
 	{
 		// success state flag
 		$this->success = true;

--- a/includes/HTTP/WebDAV/Tools/_parse_proppatch.php
+++ b/includes/HTTP/WebDAV/Tools/_parse_proppatch.php
@@ -75,7 +75,7 @@ class _parse_proppatch
      * @param  string  path of input stream 
      * @access public
      */
-    function _parse_proppatch($path) 
+    function __construct($path)
     {
         $this->success = true;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -79,7 +79,7 @@ function _destroy_user( $user_id ) {
 }
 
 function _destroy_users() {
-	global $wpdr;
+	global $wpdb;
 	$users = $wpdb->get_col( "SELECT ID from $wpdb->users" );
 		array_map( array( $this, '_destroy_user' ), $users );
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,39 @@ function _manually_load_plugin() {
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
+/**
+ * Whether we wp_die'd this test.
+ *
+ * @return bool True if wp_die() has been used. False if not.
+ */
+function _wpdr_is_wp_die() {
+	if ( isset( $GLOBALS['is_wp_die'] ) ) {
+		return $GLOBALS['is_wp_die'];
+	}
+
+	return false;
+}
+
+/**
+ * Acts as a custom wp_die() handler.
+ *
+ * This allows tests to continue, but sets a global state that
+ * we can check and manipulate.
+ */
+function _wpdr_die_handler() {
+	$GLOBALS['is_wp_die'] = true;
+}
+
+/**
+ * Registers the handler to use for a wp_die() call.
+ *
+ * @return string
+ */
+function _wpdr_die_handler_filter() {
+	return '_wpdr_die_handler';
+}
+tests_add_filter( 'wp_die_handler', '_wpdr_die_handler_filter', 100 );
+
 require $_tests_dir . '/includes/bootstrap.php';
 
 /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,5 @@
 <?php
-ob_start();
+
 $_tests_dir = getenv('WP_TESTS_DIR');
 if ( !$_tests_dir ) $_tests_dir = '/tmp/wordpress-tests-lib';
 

--- a/tests/test_document_revisions.php
+++ b/tests/test_document_revisions.php
@@ -101,6 +101,11 @@ class WP_Test_Document_Revisions extends WP_UnitTestCase {
 			'post_status' => 'inherit'
 		);
 
+		// If the directory is not available, the upload does not succeed.
+		if ( ! wp_mkdir_p( $upload_dir['path'] ) ) {
+			return false;
+		}
+
 		//copy temp test file into wp-uploads
 		copy( $file, $upload_dir['path'] . '/' . $file_array['name'] );
 

--- a/tests/test_document_rewrites.php
+++ b/tests/test_document_rewrites.php
@@ -335,33 +335,39 @@ class WP_Test_Document_Rewrites extends WP_UnitTestCase {
 
 	/**
 	 * Simulate accessing a revision log feed
+	 *
 	 * @param string $url the URL to try
+	 *
 	 * @return string the content returned
+	 * @throws Exception
 	 */
 	function simulate_feed( $url = null ) {
-
-		if ( !$url )
-			return;
+		if ( ! $url ) {
+			return '';
+		}
 
 		global $wpdr;
 		flush_rewrite_rules();
 
 		$this->go_to( $url );
-
-		ob_start();
-
 		$wpdr->revision_feed_auth();
 
-		if ( !$this->is_wp_die() )
-			do_feed();
+		if ( $this->is_wp_die() ) {
+			return '';
+		}
 
-		$content = ob_get_contents();
-		ob_end_clean();
+		ob_start();
+		global $post;
+		try {
+			@require( dirname( __DIR__ ) . '/includes/revision-feed.php' );
+			$content = ob_get_clean();
+		} catch( Exception $e ) {
+			$content = ob_get_clean();
+			throw ( $e );
+		}
 
 		return $content;
-
 	}
-
 
 	/**
 	 * Can the public access a revision log feed?

--- a/tests/test_document_rewrites.php
+++ b/tests/test_document_rewrites.php
@@ -403,12 +403,15 @@ class WP_Test_Document_Rewrites extends WP_UnitTestCase {
 
 		//try to get an auth'd feed
 		$userID = _make_user('administrator');
+		$wpdr->admin->generate_new_feed_key( $userID );
 		$key = $wpdr->admin->get_feed_key( $userID );
 
+		wp_set_current_user( $userID );
 		$content = $this->simulate_feed( add_query_arg( 'key', $key, get_permalink( $docID ) . '/feed/' ) );
 		$this->assertTrue( $wpdr->validate_feed_key(), 'not properly validating feed key' );
 		$this->assertFalse( $this->is_wp_die(), 'Not properly allowing access to feeds' );
 		$this->assertEquals( count( $wpdr->get_revisions( $docID ) ), (int) substr_count( $content, '<item>' ), 'improper feed item count' );
+		wp_set_current_user( 0 );
 		_destroy_user( $userID );
 
 	}

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -1272,10 +1272,16 @@ class Document_Revisions extends HTTP_WebDAV_Server {
 	 * @return bool true if document, false if not
 	 */
 	function verify_post_type( $post = false ) {
+		global $wp_query;
 
 		//check for post_type query arg (post new)
 		if ( $post == false && isset( $_GET['post_type'] ) && $_GET['post_type'] == 'document' )
 			return true;
+
+		// Assume that a document feed is a document feed, even without a post object.
+		if ( $post === false && is_feed() && 'document' === $wp_query->query_vars['post_type'] ) {
+			return true;
+		}
 
 		//if post isn't set, try get vars (edit post)
 		if ( $post == false )

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -142,6 +142,10 @@ class Document_Revisions extends HTTP_WebDAV_Server {
 	}
 
 	function is_webdav_client() {
+		if ( ! isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
+
 		$client = $_SERVER['HTTP_USER_AGENT'];
 		if ( strpos( $client, 'Office' ) !== false ) {
 			return true;
@@ -1912,7 +1916,7 @@ class Document_Revisions extends HTTP_WebDAV_Server {
 			return $wp;
 
 		//IE check
-		if ( stripos( $_SERVER['HTTP_USER_AGENT'], 'MSIE' ) === false )
+		if ( ! isset( $_SERVER['HTTP_USER_AGENT'] ) || stripos( $_SERVER['HTTP_USER_AGENT'], 'MSIE' ) === false )
 			return $wp;
 
 		//verify that they are requesting a document

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -1328,12 +1328,9 @@ class Document_Revisions extends HTTP_WebDAV_Server {
 		remove_filter( 'get_the_excerpt', 'twentyeleven_custom_excerpt_more' );
 
 		//include feed and die
-		include dirname( __FILE__ ) . '/includes/revision-feed.php';
-
-		global $wpdr;
+		load_template( dirname( __FILE__ ) . '/includes/revision-feed.php' );
 
 		return;
-
 	}
 
 


### PR DESCRIPTION
Howdy. I've been wanting to dive a little deeper into what maintenance of WP Document Revisions would look like and I figure the first step is to make sure the existing test structure is working. I'll follow up in #68 with some other thoughts too. :)

A variety of changes here, but the tests *should* now pass again:

* Updated the test scaffolding to the most recent `install-wp-tests.sh` and `.travis.yml` provided by the WP-CLI project. This addresses issues with the tests working at all on newer WP versions.
* Avoid a PHP notice by checking for `HTTP_USER_AGENT` before using it in the WebDAV code. The tests don't set this.
* Ensure the full upload path exists before copying test files. Previously, the first test would pass and the others would fail because the upload directory was deleted.
* Refactor feed handling so that `ob_start()` can be used selectively.
* Refactor `wp_die()` handling to be in a global spot. This isn't entirely necessary, but seems more maintainable and separates it from one of the tests classes.
* The WebDAV classes all had old PHP style constructor methods. These have been updated and no longer cause deprecation notices.

Two tests were failing once the structure was back in place.

* `test_feed_as_unauthenticated` because there was not post object to check when determining if it was a valid feed type. This is fixed via 71af069
* `test_feed_as_authorized` because the document is set as private and the user is not authenticated. This is fixed via 0831ab7.