### PR TITLE
[PR] Use H2 for "Feed Privacy" heading

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -774,7 +774,7 @@ class Document_Revisions_Admin {
 		$key = $this->get_feed_key();
 ?>
 		<div class="tool-box">
-		<h3> <?php _e( 'Feed Privacy', 'wp-document-revisions' ); ?></h3>
+		<h2><?php _e( 'Feed Privacy', 'wp-document-revisions' ); ?></h2>
 		<table class="form-table">
 			<tr id="document_revisions_feed_key">
 				<th><label for="feed_key"><?php _e( 'Secret Feed Key', 'wp-document-revisions' ); ?></label></th>


### PR DESCRIPTION
In WordPress 4.3, admin page headings were changed to use H1 as the main heading. Other heading levels can be updated to match.

See https://make.wordpress.org/core/2015/07/31/headings-in-admin-screens-change-in-wordpress-4-3/

Fixes #88.