### PR TITLE
Update class-wp-document-revisions-front-end.php

### DIFF
--- a/includes/class-wp-document-revisions-front-end.php
+++ b/includes/class-wp-document-revisions-front-end.php
@@ -312,7 +312,8 @@ class Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 		<?php
 		endforeach;
 
-		echo esc_html( '</ul>' . $args['after_widget'] );
+		// @codingStandardsIgnoreLine WordPress.XSS.EscapeOutput.OutputNotEscaped
+		echo '</ul>' . $args['after_widget'];
 	}
 
 


### PR DESCRIPTION
Do not escape end list widget html in function widget. 
Add comment to avoid coding standards "error".
Addresses Issue #98 raised by me.