### PR TITLE
Use Ubuntu Precise for PHP 5.3 build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
     - php: 5.6
       env: WP_VERSION=latest
     - php: 5.3
+      dist: precise
       env: WP_VERSION=latest
     - php: 7.1
       env: WP_TRAVISCI=phpcs


### PR DESCRIPTION
PHP 5.3 is not supported on Trusty, which is used by default in Travis.

See https://docs.travis-ci.com/user/reference/trusty#PHP-images

This should resolve the current CI errors.

(Sorry for bailing on you earlier in the year, @benbalter. Things got nuts 🙈 )