### PR TITLE
Only cache revisions output if revisions exist

### DIFF
--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -663,11 +663,15 @@ class WP_Document_Revisions {
 		);
 
 		$i = 1;
+
+		$output = array();
 		foreach ( $revs as $rev ) {
 			$output[ $i++ ] = $rev->ID;
 		}
 
-		wp_cache_set( $post_id, $output, 'document_revision_indices' );
+		if ( ! empty( $output ) ) {
+			wp_cache_set( $post_id, $output, 'document_revision_indices' );
+		}
 
 		return $output;
 


### PR DESCRIPTION
In some cases, and likely due to some other customization by another plugin, it's possible to generate a post save without entering a title or content and with no revision.

It appears that in these cases, the `get_revision_indices()` method attempts to cache an `$output` variable that doesn't exist. Shortly after, the `get_revision_number()` method attempts to `array_search()` on a piece of data that is not an array.

```
PHP Warning:  array_search() expects parameter 2 to be array, null given in /var/www/wp-content/plugins/wp-document-revisions/includes/class-wp-document-revisions.php on line 694
```

This commit sets `$output` to an empty array and, if no data is stored in it, avoids storing it in cache and returns it as is.