### PR TITLE
Fix possible data pollution in archive views

### DIFF
--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -1281,7 +1281,7 @@ class WP_Document_Revisions_Admin {
 	function revision_filter( $id ) {
 
 		// verify post type
-		if ( ! $this->verify_post_type() ) {
+		if ( ! $this->verify_post_type( $id ) ) {
 			return;
 		}
 
@@ -1348,7 +1348,7 @@ class WP_Document_Revisions_Admin {
 		global $post;
 
 		// verify that this is a new document
-		if ( ! isset( $post ) || ! $this->verify_post_type() || strlen( $post->post_content ) > 0 ) {
+		if ( ! isset( $post ) || ! $this->verify_post_type( $post ) || strlen( $post->post_content ) > 0 ) {
 			return;
 		}
 

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1160,7 +1160,12 @@ class WP_Document_Revisions {
 			}
 		}
 
-		$post_type = get_post_type( $documentish );
+		if ( false === $documentish ) {
+			return false;
+		}
+
+		$post = get_post( $documentish );
+		$post_type = $post->post_type;
 
 		// if post is really an attachment or revision, look to the post's parent
 		if ( 'attachment' === $post_type || 'revision' === $post_type ) {

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -78,9 +78,9 @@ class WP_Document_Revisions {
 		add_filter( 'redirect_canonical', array( &$this, 'redirect_canonical_filter' ), 10, 2 );
 
 		// RSS
-		add_filter( 'private_title_format', array( &$this, 'no_title_prepend' ), 20, 1 );
-		add_filter( 'protected_title_format', array( &$this, 'no_title_prepend' ), 20, 1 );
-		add_filter( 'the_title', array( &$this, 'add_revision_num_to_title' ), 20, 1 );
+		add_filter( 'private_title_format', array( &$this, 'no_title_prepend' ), 20, 2 );
+		add_filter( 'protected_title_format', array( &$this, 'no_title_prepend' ), 20, 2 );
+		add_filter( 'the_title', array( &$this, 'add_revision_num_to_title' ), 20, 2 );
 
 		// uploads
 		add_filter( 'upload_dir', array( &$this, 'document_upload_dir_filter' ), 10, 2 );
@@ -1475,12 +1475,13 @@ class WP_Document_Revisions {
 	 * Removes Private or Protected from document titles in RSS feeds
 	 *
 	 * @since 1.0
-	 * @param string $prepend the sprintf formatted string to prepend to the title
+	 * @param string  $prepend the sprintf formatted string to prepend to the title
+	 * @param WP_Post $post    The post object for which the title is being generated.
 	 * @return string just the string
 	 */
-	function no_title_prepend( $prepend ) {
+	function no_title_prepend( $prepend, $post ) {
 
-		if ( ! $this->verify_post_type() ) {
+		if ( ! $this->verify_post_type( $post ) ) {
 			return $prepend;
 		}
 
@@ -1490,17 +1491,18 @@ class WP_Document_Revisions {
 
 
 	/**
-	 * Adds revision number to document tiles
+	 * Adds revision number to document titles
 	 *
 	 * @since 1.0
-	 * @param string $title the title
+	 * @param string $title   the title
+	 * @param int    $post_id The ID of the post for which the title is being generated.
 	 * @return string the title possibly with the revision number
 	 */
-	function add_revision_num_to_title( $title ) {
-		global $post;
+	function add_revision_num_to_title( $title, $post_id ) {
+		$post = get_post( $post_id );
 
 		// verify post type
-		if ( ! $this->verify_post_type() ) {
+		if ( ! $this->verify_post_type( $post ) ) {
 			return $title;
 		}
 
@@ -1539,7 +1541,7 @@ class WP_Document_Revisions {
 	 */
 	function content_filter( $content ) {
 
-		if ( ! $this->verify_post_type() ) {
+		if ( ! $this->verify_post_type( get_post() ) ) {
 			return $content;
 		}
 

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1128,7 +1128,11 @@ class WP_Document_Revisions {
 
 	/**
 	 * Checks if a given post is a document
-	 * note: We can't use the screen API because A) used on front end, and B) admin_init is too early (enqueue scripts)
+	 *
+	 * When called with `false`, will look to other available global data to determine whether
+	 * this request is for a document post type. Will *not* look to the global `$post` object.
+	 *
+	 * Note: We can't use the screen API because A) used on front end, and B) admin_init is too early (enqueue scripts)
 	 *
 	 * @param object|int|bool $documentish a post object, postID, or false
 	 * @since 0.5

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1168,8 +1168,8 @@ class WP_Document_Revisions {
 		$post_type = $post->post_type;
 
 		// if post is really an attachment or revision, look to the post's parent
-		if ( 'attachment' === $post_type || 'revision' === $post_type ) {
-			$post_type = get_post_type( get_post( $documentish )->post_parent );
+		if ( ( 'attachment' === $post_type || 'revision' === $post_type ) && 0 !== $post->post_parent ) {
+			$post_type = get_post_type( $post->post_parent );
 		}
 
 		return 'document' === $post_type;

--- a/tests/class-test-wp-document-revisions.php
+++ b/tests/class-test-wp-document-revisions.php
@@ -355,7 +355,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 		$post = get_post( $doc_id );
 		// @codingStandardsIgnoreEnd WordPress.Variables.GlobalVariables.OverrideProhibited
 
-		$this->assertTrue( $wpdr->verify_post_type(), 'verify post type via global $post' );
+		$this->assertTrue( $wpdr->verify_post_type( $post ), 'verify post type via global $post' );
 		unset( $post );
 
 		$this->assertTrue( $wpdr->verify_post_type( $doc_id ) );


### PR DESCRIPTION
**Original reported issue:** When documents appear in search results, and a site's theme (Twenty Seventeen) is using a custom logo, the custom logo does not display. 

**Resolution:** WP Document Revisions was applying its `image_downsize` filtering to all images on the search page view because the first result was a document and `verify_post_type()` assumed a document page load.

The `verify_post_type()` method assumes `false` if no other data is passed to it and attempts to determine a valid post ID based on the global data available to it. In some cases, this determination
can be wrong due to how things are passed around in WordPress.

In several cases, we already have a `WP_Post` object or post ID and can call `verify_post_type( $arg )` with that data directly. In other cases, we really do care about the global scope and these can be left to call `verify_post_type()` with no arguments.

Additionally, in `verify_post_type()`, we can make empty results more reliable and improve the detection of a `document` or revision/attachment of a `document`.