### PR TITLE
[PR] Update WPCS and adjust code to meet new standards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require-dev": {
       "phpunit/phpunit": "~5.6",
       "wp-cli/wp-cli": "~0.22",
-      "wp-coding-standards/wpcs": "^0.10.0"
+      "wp-coding-standards/wpcs": "^0.14.0"
     },
     "config": {
      "bin-dir": "bin",

--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -6,9 +6,9 @@
  * @package WP Document Revisions
  */
 
- /**
-  * The WP Admin backend object
-  */
+/**
+ * The WP Admin backend object
+ */
 class WP_Document_Revisions_Admin {
 
 	/**
@@ -214,7 +214,7 @@ class WP_Document_Revisions_Admin {
 				__( 'Documents', 'wp-document-revisions' ) =>
 				'<p>' . __( 'Below is a list of all documents to which you have access. Click the document title to edit the document or download the latest version.', 'wp-document-revisions' ) . '</p><p>' .
 				__( 'To add a new document, click <strong>Add Document</strong> on the left-hand side.', 'wp-document-revisions' ) . '</p><p>' .
-			  __( 'To view all documents at a particular workflow state, click <strong>Workflow States</strong> in the menu on the left.', 'wp-document-revisions' ) . '</p>',
+				__( 'To view all documents at a particular workflow state, click <strong>Workflow States</strong> in the menu on the left.', 'wp-document-revisions' ) . '</p>',
 			),
 		);
 
@@ -782,7 +782,7 @@ class WP_Document_Revisions_Admin {
 		// if there is no page var, this is a new document, no need to warn
 		if ( isset( $_GET['post'] ) ) :
 		?>
-		 <div class="error" id="lock-notice"><p><?php esc_html_e( 'You currently have this file checked out. No other user can edit this document so long as you remain on this page.', 'wp-document-revisions' ); ?></p></div>
+		<div class="error" id="lock-notice"><p><?php esc_html_e( 'You currently have this file checked out. No other user can edit this document so long as you remain on this page.', 'wp-document-revisions' ); ?></p></div>
 			<?php
 			endif;
 	}

--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -16,14 +16,14 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @var $parent
 	 */
-	static $parent;
+	public static $parent;
 
 	/**
 	 * The singelton instance
 	 *
 	 * @var $instance
 	 */
-	static $instance;
+	public static $instance;
 
 	/**
 	 * Register's admin hooks
@@ -32,7 +32,7 @@ class WP_Document_Revisions_Admin {
 	 * @since 0.5
 	 * @param unknown $instance (optional, reference)
 	 */
-	function __construct( &$instance = null ) {
+	public function __construct( &$instance = null ) {
 
 		self::$instance = &$this;
 
@@ -105,7 +105,7 @@ class WP_Document_Revisions_Admin {
 	 * @param array    $args the arguments to pass to the function
 	 * @returns mixed the result of the function
 	 */
-	function __call( $function, $args ) {
+	public function __call( $function, $args ) {
 		return call_user_func_array( array( &self::$parent, $function ), $args );
 	}
 
@@ -117,7 +117,7 @@ class WP_Document_Revisions_Admin {
 	 * @param string $name the property to fetch
 	 * @returns mixed the property's value
 	 */
-	function __get( $name ) {
+	public function __get( $name ) {
 		return WP_Document_Revisions::$$name;
 	}
 
@@ -129,7 +129,7 @@ class WP_Document_Revisions_Admin {
 	 * @param array $messages messages array
 	 * @returns array messages array with doc. messages
 	 */
-	function update_messages( $messages ) {
+	public function update_messages( $messages ) {
 		global $post, $post_id;
 
 		$messages['document'] = array(
@@ -162,7 +162,7 @@ class WP_Document_Revisions_Admin {
 	 * @uses get_help_text()
 	 * @return void
 	 */
-	function add_help_tab() {
+	public function add_help_tab() {
 
 		$screen = get_current_screen();
 
@@ -187,7 +187,7 @@ class WP_Document_Revisions_Admin {
 	 * @param bool   $return_array (optional) whether to return as an array or string
 	 * @returns array|string the help text
 	 */
-	function get_help_text( $screen = null, $return_array = true ) {
+	public function get_help_text( $screen = null, $return_array = true ) {
 
 		if ( is_null( $screen ) ) {
 			$screen = get_current_screen();
@@ -235,7 +235,7 @@ class WP_Document_Revisions_Admin {
 	 * Callback to manage metaboxes on edit page
 	 * @ since 0.5
 	 */
-	function meta_cb() {
+	public function meta_cb() {
 
 		global $post;
 
@@ -279,7 +279,7 @@ class WP_Document_Revisions_Admin {
 	 * @param array $screen the current screen
 	 * @returns array defaults with postcustom
 	 */
-	function hide_postcustom_metabox( $hidden, $screen ) {
+	public function hide_postcustom_metabox( $hidden, $screen ) {
 		if ( 'document' === $screen->id ) {
 			$hidden[] = 'postcustom';
 		}
@@ -294,7 +294,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @param String $body_class the existing body class(es)
 	 */
-	function admin_body_class_filter( $body_class ) {
+	public function admin_body_class_filter( $body_class ) {
 
 		global $post;
 
@@ -319,7 +319,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 1.2.4
 	 */
-	function hide_upload_header() {
+	public function hide_upload_header() {
 
 		if ( 'media-upload' === get_current_screen()->id && $this->verify_post_type( $_GET['post_id'] ) ) { ?>
 			<style>
@@ -336,7 +336,7 @@ class WP_Document_Revisions_Admin {
 	 * @since 0.5
 	 * @param object $post the post object
 	 */
-	function document_metabox( $post ) {
+	public function document_metabox( $post ) {
 	?>
 		<input type="hidden" id="content" name="content" value="<?php echo esc_attr( $post->post_content ); ?>" />
 		<?php
@@ -385,7 +385,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 0.5
 	 */
-	function revision_summary_cb() {
+	public function revision_summary_cb() {
 	?>
 		<label class="screen-reader-text" for="excerpt"><?php esc_html_e( 'Revision Summary' ); ?></label>
 		<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt"></textarea>
@@ -400,7 +400,7 @@ class WP_Document_Revisions_Admin {
 	 * @since 0.5
 	 * @param object $post the post object
 	 */
-	function revision_metabox( $post ) {
+	public function revision_metabox( $post ) {
 
 		$can_edit_post = current_user_can( 'edit_post', $post->ID );
 		$revisions = $this->get_revisions( $post->ID );
@@ -470,7 +470,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 0.5
 	 */
-	function enqueue_edit_scripts() {
+	public function enqueue_edit_scripts() {
 
 		if ( ! $this->verify_post_type() ) {
 			return;
@@ -487,7 +487,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 0.5
 	 */
-	function settings_fields() {
+	public function settings_fields() {
 		register_setting( 'media', 'document_upload_directory', array( &$this, 'sanitize_upload_dir' ) );
 		register_setting( 'media', 'document_slug', array( &$this, 'sanitize_document_slug' ) );
 		add_settings_field( 'document_upload_directory', __( 'Document Upload Directory', 'wp-document-revisions' ), array( &$this, 'upload_location_cb' ), 'media', 'uploads' );
@@ -503,7 +503,7 @@ class WP_Document_Revisions_Admin {
 	 * @param string $dir path to the new directory
 	 * @returns bool|string false on fail, path to new dir on sucess
 	 */
-	function sanitize_upload_dir( $dir ) {
+	public function sanitize_upload_dir( $dir ) {
 
 		// empty string passed
 		if ( '' === $dir ) {
@@ -537,7 +537,7 @@ class WP_Document_Revisions_Admin {
 	 * @param string $slug new slug
 	 * @return string sanitized slug
 	 */
-	function sanitize_document_slug( $slug ) {
+	public function sanitize_document_slug( $slug ) {
 
 		$slug = sanitize_title( $slug, 'documents' );
 
@@ -561,7 +561,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 1.0
 	 */
-	function network_settings_cb() {
+	public function network_settings_cb() {
 	?>
 		<h3><?php esc_html_e( 'Document Settings', 'wp-document-revisions' ); ?></h3>
 		<table id="document_settings" class="form-table">
@@ -589,7 +589,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 1.0
 	 */
-	function network_upload_location_save() {
+	public function network_upload_location_save() {
 
 		if ( ! isset( $_POST['document_upload_location_nonce'] ) ) {
 			return;
@@ -617,7 +617,7 @@ class WP_Document_Revisions_Admin {
 	/**
 	 * Callback to validate and save slug on network settings page
 	 */
-	function network_slug_save() {
+	public function network_slug_save() {
 
 		if ( ! isset( $_POST['document_slug_nonce'] ) ) {
 			return;
@@ -647,7 +647,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 1.0
 	 */
-	function network_settings_errors() {
+	public function network_settings_errors() {
 		settings_errors( 'document_upload_directory' );
 		settings_errors( 'document_slug' );
 	}
@@ -660,7 +660,7 @@ class WP_Document_Revisions_Admin {
 	 * @param string $location the URL being redirected to
 	 * @returns string the modified location
 	 */
-	function network_settings_redirect( $location ) {
+	public function network_settings_redirect( $location ) {
 
 		// Verify redirect string from /wp-admin/network/edit.php line 164
 		if ( add_query_arg( 'updated', 'true', network_admin_url( 'settings.php' ) ) === $location ) {
@@ -677,7 +677,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 0.5
 	 */
-	function upload_location_cb() {
+	public function upload_location_cb() {
 	?>
 		<input name="document_upload_directory" type="text" id="document_upload_directory" value="<?php echo esc_attr( $this->document_upload_dir() ); ?>" class="large-text code" /><br />
 		<span class="description"><?php esc_html_e( 'Directory in which to store uploaded documents. The default is in your <code>wp_content/uploads</code> folder (or another default uploads folder defined elsewhere), but it may be moved to a folder outside of the <code>htdocs</code> or <code>public_html</code> folder for added security.', 'wp-document-revisions' ); ?></span>
@@ -696,7 +696,7 @@ class WP_Document_Revisions_Admin {
 	/**
 	 * Callback to create the document slug settings field
 	 */
-	function document_slug_cb() {
+	public function document_slug_cb() {
 	?>
 	<code><?php bloginfo( 'url' ); ?>/<input name="document_slug" type="text" id="document_slug" value="<?php echo esc_attr( $this->document_slug() ); ?>" class="medium-text" />/<?php echo esc_html( date( 'Y' ) ); ?>/<?php echo esc_html( date( 'm' ) ); ?>/<?php esc_html_e( 'example-document-title', 'wp-document-revisions' ); ?>.txt</code><br />
 	<span class="description"><?php esc_html_e( '"Slug" with which to prefix all URLs for documents (and the document archive). Default is <code>documents</code>.', 'wp-document-revisions' ); ?></span>
@@ -711,7 +711,7 @@ class WP_Document_Revisions_Admin {
 	 * @param int $id the ID of the attachment
 	 * @return unknown
 	 */
-	function post_upload_js( $id ) {
+	public function post_upload_js( $id ) {
 
 		// get the post object
 		$document = get_post( $id );
@@ -744,7 +744,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 1.2.1
 	 */
-	function bind_upload_cb() {
+	public function bind_upload_cb() {
 		global $pagenow;
 
 		if ( 'media-upload.php' === $pagenow ) :
@@ -762,7 +762,7 @@ class WP_Document_Revisions_Admin {
 	 * @param int $post_id the parent post
 	 * @returns object the attachment object
 	 */
-	function get_latest_attachment( $post_id ) {
+	public function get_latest_attachment( $post_id ) {
 		$attachments = $this->get_attachments( $post_id );
 
 		return reset( $attachments );
@@ -774,7 +774,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 0.5
 	 */
-	function lock_notice() {
+	public function lock_notice() {
 		global $post;
 
 		do_action( 'document_lock_notice', $post );
@@ -793,7 +793,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 0.5
 	 */
-	function rss_key_display() {
+	public function rss_key_display() {
 		$key = $this->get_feed_key();
 ?>
 		<div class="tool-box">
@@ -821,7 +821,7 @@ class WP_Document_Revisions_Admin {
 	 * @param int $user (optional) UserID
 	 * @returns string the feed key
 	 */
-	function get_feed_key( $user = null ) {
+	public function get_feed_key( $user = null ) {
 
 		$key = get_user_option( $this->meta_key, $user );
 
@@ -840,7 +840,7 @@ class WP_Document_Revisions_Admin {
 	 * @param int $user (optional) UserID
 	 * @returns string feed key
 	 */
-	function generate_new_feed_key( $user = null ) {
+	public function generate_new_feed_key( $user = null ) {
 
 		if ( ! $user ) {
 			$user = get_current_user_id();
@@ -858,7 +858,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 0.5
 	 */
-	function profile_update_cb() {
+	public function profile_update_cb() {
 
 		if ( isset( $_POST['generate-new-feed-key'] ) && isset( $_POST['_document_revisions_nonce'] ) && wp_verify_nonce( $_POST['_document_revisions_nonce'], 'generate-new-feed-key' ) ) {
 			$this->generate_new_feed_key();
@@ -868,7 +868,7 @@ class WP_Document_Revisions_Admin {
 	/**
 	 * Allow some filtering of the All Documents list
 	 */
-	function filter_documents_list() {
+	public function filter_documents_list() {
 		global $typenow, $wp_query;
 		// Only applies to document post type
 		if ( 'document' === $typenow ) {
@@ -913,7 +913,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @param Object $query the WP_Query object
 	 */
-	function convert_id_to_term( $query ) {
+	public function convert_id_to_term( $query ) {
 		global $pagenow, $typenow;
 		if ( 'edit.php' === $pagenow && 'document' === $typenow ) {
 			$tax_slug = 'workflow_state';
@@ -935,7 +935,7 @@ class WP_Document_Revisions_Admin {
 	 * @param array $defaults the default column labels
 	 * @returns array the modified column labels
 	 */
-	function rename_author_column( $defaults ) {
+	public function rename_author_column( $defaults ) {
 
 		if ( isset( $defaults['author'] ) ) {
 			$defaults['author'] = __( 'Owner', 'wp-document-revisions' );
@@ -952,7 +952,7 @@ class WP_Document_Revisions_Admin {
 	 * @param array $defaults the original columns
 	 * @returns array our spliced columns
 	 */
-	function add_workflow_state_column( $defaults ) {
+	public function add_workflow_state_column( $defaults ) {
 
 		// get checkbox and title
 		$output = array_slice( $defaults, 0, 2 );
@@ -974,7 +974,7 @@ class WP_Document_Revisions_Admin {
 	 * @param string $column_name the name of the column being propegated
 	 * @param int    $post_id the ID of the post being displayed
 	 */
-	function workflow_state_column_cb( $column_name, $post_id ) {
+	public function workflow_state_column_cb( $column_name, $post_id ) {
 
 		// verify column
 		if ( 'workflow_state' === $column_name && $this->verify_post_type( $post_id ) ) {
@@ -1000,7 +1000,7 @@ class WP_Document_Revisions_Admin {
 	 * @param array $defaults the original columns
 	 * @returns array our spliced columns
 	 */
-	function add_currently_editing_column( $defaults ) {
+	public function add_currently_editing_column( $defaults ) {
 
 		// get checkbox, title, and workflow state
 		$output = array_slice( $defaults, 0, 3 );
@@ -1022,7 +1022,7 @@ class WP_Document_Revisions_Admin {
 	 * @param string $column_name the name of the column being propegated
 	 * @param int    $post_id the ID of the post being displayed
 	 */
-	function currently_editing_column_cb( $column_name, $post_id ) {
+	public function currently_editing_column_cb( $column_name, $post_id ) {
 
 		// verify column
 		if ( 'currently_editing' === $column_name && $this->verify_post_type( $post_id ) ) {
@@ -1042,7 +1042,7 @@ class WP_Document_Revisions_Admin {
 	 * @since 0.5
 	 * @param object $post the post object
 	 */
-	function workflow_state_metabox_cb( $post ) {
+	public function workflow_state_metabox_cb( $post ) {
 
 		wp_nonce_field( 'wp-document-revisions', 'workflow_state_nonce' );
 
@@ -1076,7 +1076,7 @@ class WP_Document_Revisions_Admin {
 	 * @since 0.5
 	 * @param int $doc_id the ID of the post being edited
 	 */
-	function workflow_state_save( $doc_id ) {
+	public function workflow_state_save( $doc_id ) {
 
 		// autosave check
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
@@ -1123,7 +1123,7 @@ class WP_Document_Revisions_Admin {
 	 * @since 0.5
 	 * @param object $post the post object
 	 */
-	function post_author_meta_box( $post ) {
+	public function post_author_meta_box( $post ) {
 		global $user_id;
 ?>
 		<label class="screen-reader-text" for="post_author_override"><?php esc_html_e( 'Owner', 'wp-document-revisions' ); ?></label>
@@ -1143,7 +1143,7 @@ class WP_Document_Revisions_Admin {
 	/**
 	 * Back Compat
 	 */
-	function enqueue_js() {
+	public function enqueue_js() {
 		_deprecated_function( __FUNCTION__, '1.3.2 of WP Document Revisions', 'enqueue' );
 		$this->enqueue();
 
@@ -1153,7 +1153,7 @@ class WP_Document_Revisions_Admin {
 	/**
 	 * Enqueue admin JS and CSS files
 	 */
-	function enqueue() {
+	public function enqueue() {
 
 		// only include JS on document pages
 		if ( ! $this->verify_post_type() ) {
@@ -1206,7 +1206,7 @@ class WP_Document_Revisions_Admin {
 	 * @param string $join the original join statement
 	 * @return string the modified join statement
 	 */
-	function filter_media_join( $join ) {
+	public function filter_media_join( $join ) {
 		global $wpdb;
 
 		$join .= " LEFT OUTER JOIN {$wpdb->posts} wpdr_post_parent ON wpdr_post_parent.ID = {$wpdb->posts}.post_parent";
@@ -1222,7 +1222,7 @@ class WP_Document_Revisions_Admin {
 	 * @param string $where the original where statement
 	 * @return string the modified where statement
 	 */
-	function filter_media_where( $where ) {
+	public function filter_media_where( $where ) {
 		global $wpdb;
 
 		// fix for mysql column ambiguity
@@ -1242,7 +1242,7 @@ class WP_Document_Revisions_Admin {
 	 * @uses filter_media_where()
 	 * @uses filter_media_join()
 	 */
-	function filter_from_media() {
+	public function filter_from_media() {
 
 		global $pagenow;
 
@@ -1278,7 +1278,7 @@ class WP_Document_Revisions_Admin {
 	 * @since 1.0
 	 * @param int $id the post id
 	 */
-	function revision_filter( $id ) {
+	public function revision_filter( $id ) {
 
 		// verify post type
 		if ( ! $this->verify_post_type() ) {
@@ -1298,7 +1298,7 @@ class WP_Document_Revisions_Admin {
 	 * @since 1.0
 	 * @param int $post_id the id of the deleted post
 	 */
-	function delete_attachments_with_document( $post_id ) {
+	public function delete_attachments_with_document( $post_id ) {
 
 		if ( ! $this->verify_post_type( $post_id ) ) {
 			return;
@@ -1317,7 +1317,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 1.1
 	 */
-	function edit_flow_admin_support() {
+	public function edit_flow_admin_support() {
 		_deprecated_function( 'edit_flow_admin_support', '1.3.2 of WP Document Revisions', 'disable_workflow_states' );
 	}
 
@@ -1326,7 +1326,7 @@ class WP_Document_Revisions_Admin {
 	 * Remove all hooks that activate workflow state support
 	 * use filter `document_use_workflow_states` to disable
 	 */
-	function disable_workflow_states() {
+	public function disable_workflow_states() {
 
 		if ( self::$parent->use_workflow_states() ) {
 			return false;
@@ -1344,7 +1344,7 @@ class WP_Document_Revisions_Admin {
 	 *
 	 * @since 0.5
 	 */
-	function make_private() {
+	public function make_private() {
 		global $post;
 
 		// verify that this is a new document

--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -1166,22 +1166,22 @@ class WP_Document_Revisions_Admin {
 			'lockNeedle'          => __( 'is currently editing this' ), // purposely left out text domain
 			'postUploadNotice'    => '<div id="message" class="updated" style="display:none"><p>' . __( 'File uploaded successfully. Add a revision summary below (optional) or press <strong>Update</strong> to save your changes.', 'wp-document-revisions' ) . '</p></div>',
 			'postDesktopNotice'   => '<div id="message" class="update-nag" style="display:none"><p>' . __( 'After you have saved your document in your office software, <a href="#" onClick="location.reload();">reload this page</a> to see your changes.', 'wp-document-revisions' ) . '</p></div>',
-		// translators: %s is the title of the document
+			// translators: %s is the title of the document
 			'lostLockNotice'      => __( 'Your lock on the document %s has been overridden. Any changes will be lost.', 'wp-document-revisions' ),
 			'lockError'           => __( 'An error has occurred, please try reloading the page.', 'wp-document-revisions' ),
 			'lostLockNoticeTitle' => __( 'Lost Document Lock', 'wp-document-revisions' ),
 			'lostLockNoticeLogo'  => admin_url( 'images/logo.gif' ),
-		// translators: %d is the numeric minutes, when singular
+			// translators: %d is the numeric minutes, when singular
 			'minute'              => __( '%d mins', 'wp-document-revisions' ),
-		// translators: %d is the numeric minutes, when plural
+			// translators: %d is the numeric minutes, when plural
 			'minutes'             => __( '%d mins', 'wp-document-revisions' ),
-		// translators: %d is the numeric hour, when singular
+			// translators: %d is the numeric hour, when singular
 			'hour'                => __( '%d hour', 'wp-document-revisions' ),
-		// translators: %d is the numeric hour, when plural
+			// translators: %d is the numeric hour, when plural
 			'hours'               => __( '%d hours', 'wp-document-revisions' ),
-		// translators: %d is the numeric day, when singular
+			// translators: %d is the numeric day, when singular
 			'day'                 => __( '%d day', 'wp-document-revisions' ),
-		// translators: %d is the numeric days, when plural
+			// translators: %d is the numeric days, when plural
 			'days'                => __( '%d days', 'wp-document-revisions' ),
 			'offset'              => get_option( 'gmt_offset' ) * 3600,
 			'nonce'               => wp_create_nonce( 'wp-document-revisions' ),

--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -1103,7 +1103,7 @@ class WP_Document_Revisions_Admin {
 			$doc_id = wp_is_post_revision( $doc_id );
 		}
 
-		$old = wp_get_post_terms( $doc_id,  'workflow_state', true );
+		$old = wp_get_post_terms( $doc_id, 'workflow_state', true );
 
 		// no change, keep moving
 		if ( isset( $old[0] ) && $old[0]->slug === $_POST['workflow_state'] ) {
@@ -1165,7 +1165,7 @@ class WP_Document_Revisions_Admin {
 			'restoreConfirmation' => __( 'Are you sure you want to restore this revision? If you do, no history will be lost. This revision will be copied and become the most recent revision.', 'wp-document-revisions' ),
 			'lockNeedle'          => __( 'is currently editing this' ), // purposely left out text domain
 			'postUploadNotice'    => '<div id="message" class="updated" style="display:none"><p>' . __( 'File uploaded successfully. Add a revision summary below (optional) or press <strong>Update</strong> to save your changes.', 'wp-document-revisions' ) . '</p></div>',
-			'postDesktopNotice'    => '<div id="message" class="update-nag" style="display:none"><p>' . __( 'After you have saved your document in your office software, <a href="#" onClick="location.reload();">reload this page</a> to see your changes.', 'wp-document-revisions' ) . '</p></div>',
+			'postDesktopNotice'   => '<div id="message" class="update-nag" style="display:none"><p>' . __( 'After you have saved your document in your office software, <a href="#" onClick="location.reload();">reload this page</a> to see your changes.', 'wp-document-revisions' ) . '</p></div>',
 		// translators: %s is the title of the document
 			'lostLockNotice'      => __( 'Your lock on the document %s has been overridden. Any changes will be lost.', 'wp-document-revisions' ),
 			'lockError'           => __( 'An error has occurred, please try reloading the page.', 'wp-document-revisions' ),
@@ -1184,7 +1184,7 @@ class WP_Document_Revisions_Admin {
 		// translators: %d is the numeric days, when plural
 			'days'                => __( '%d days', 'wp-document-revisions' ),
 			'offset'              => get_option( 'gmt_offset' ) * 3600,
-		'nonce'               => wp_create_nonce( 'wp-document-revisions' ),
+			'nonce'               => wp_create_nonce( 'wp-document-revisions' ),
 		);
 
 		$wpdr = self::$parent;

--- a/includes/class-wp-document-revisions-front-end.php
+++ b/includes/class-wp-document-revisions-front-end.php
@@ -16,14 +16,14 @@ class WP_Document_Revisions_Front_End {
 	 *
 	 * @var $parent
 	 */
-	static $parent;
+	public static $parent;
 
 	/**
 	 * The Singleton instance
 	 *
 	 * @var $instance
 	 */
-	static $instance;
+	public static $instance;
 
 	/**
 	 * Array of accepted shortcode keys and default values
@@ -40,7 +40,7 @@ class WP_Document_Revisions_Front_End {
 	 *
 	 * @param Object $instance The WP Document Revisions instance
 	 */
-	function __construct( &$instance = null ) {
+	public function __construct( &$instance = null ) {
 
 		self::$instance = &$this;
 
@@ -65,7 +65,7 @@ class WP_Document_Revisions_Front_End {
 	 * @param array    $args the arguments to pass to the function
 	 * @returns mixed the result of the function
 	 */
-	function __call( $function, $args ) {
+	public function __call( $function, $args ) {
 		return call_user_func_array( array( &self::$parent, $function ), $args );
 	}
 
@@ -77,7 +77,7 @@ class WP_Document_Revisions_Front_End {
 	 * @param string $name the property to fetch
 	 * @returns mixed the property's value
 	 */
-	function __get( $name ) {
+	public function __get( $name ) {
 		return Document_Revisions::$$name;
 	}
 
@@ -89,7 +89,7 @@ class WP_Document_Revisions_Front_End {
 	 * @returns string a UL with the revisions
 	 * @since 1.2
 	 */
-	function revisions_shortcode( $atts ) {
+	public function revisions_shortcode( $atts ) {
 
 		// normalize args
 		$atts = shortcode_atts( $this->shortcode_defaults, $atts );
@@ -143,7 +143,7 @@ class WP_Document_Revisions_Front_End {
 	 * @param array $atts shortcode attributes
 	 * @return string the shortcode output
 	 */
-	function documents_shortcode( $atts ) {
+	public function documents_shortcode( $atts ) {
 
 		$defaults = array(
 			'orderby' => 'modified',
@@ -207,7 +207,7 @@ class WP_Document_Revisions_Front_End {
 	 * @param Array $atts shortcode attributes
 	 * @return Array modified shortcode attributes
 	 */
-	function shortcode_atts_hyphen_filter( $atts ) {
+	public function shortcode_atts_hyphen_filter( $atts ) {
 
 		foreach ( (array) $atts as $k => $v ) {
 
@@ -253,7 +253,7 @@ class Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	/**
 	 * Init widget and register
 	 */
-	function __construct() {
+	public function __construct() {
 		parent::__construct( 'Document_Revisions_Recently_Revised_Widget', __( 'Recently Revised Documents', 'wp-document-revisions' ) );
 
 		// can't i18n outside of a function
@@ -267,7 +267,7 @@ class Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	 * @param Array  $args the widget arguments
 	 * @param Object $instance the WP Document Revisions instance
 	 */
-	function widget( $args, $instance ) {
+	public function widget( $args, $instance ) {
 
 		global $wpdr;
 		if ( ! $wpdr ) {
@@ -322,7 +322,7 @@ class Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	 *
 	 * @param Object $instance the WP Document Revisions instance
 	 */
-	function form( $instance ) {
+	public function form( $instance ) {
 
 		foreach ( $this->defaults as $key => $value ) {
 			if ( ! isset( $instance[ $key ] ) ) {
@@ -359,7 +359,7 @@ class Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	 * @param Object $new_instance the new instance
 	 * @param Object $old_instance the old instance
 	 */
-	function update( $new_instance, $old_instance ) {
+	public function update( $new_instance, $old_instance ) {
 
 		$instance = $old_instance;
 		$instance['title']       = strip_tags( $new_instance['title'] );
@@ -380,7 +380,7 @@ class Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 /**
  * Callback to register the recently revised widget
  */
-function drrrw_widgets_init() {
+public function drrrw_widgets_init() {
 	register_widget( 'Document_Revisions_Recently_Revised_Widget' );
 }
 

--- a/includes/class-wp-document-revisions-front-end.php
+++ b/includes/class-wp-document-revisions-front-end.php
@@ -380,7 +380,7 @@ class Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 /**
  * Callback to register the recently revised widget
  */
-public function drrrw_widgets_init() {
+function drrrw_widgets_init() {
 	register_widget( 'Document_Revisions_Recently_Revised_Widget' );
 }
 

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -30,7 +30,7 @@ class WP_Document_Revisions {
 	 *
 	 * @var String $meta_key
 	 */
-	public static $meta_key   = 'document_revisions_feed_key';
+	public static $meta_key = 'document_revisions_feed_key';
 
 	/**
 	 * The plugin version
@@ -504,7 +504,7 @@ class WP_Document_Revisions {
 		if ( '' === $wp_rewrite->permalink_structure || in_array( $document->post_status, array( 'pending', 'draft' ), true ) ) {
 			$link = site_url( '?post_type=document&p=' . $document->ID );
 			if ( $revision_num ) {
-				 $link = add_query_arg( 'revision', $revision_num, $link );
+				$link = add_query_arg( 'revision', $revision_num, $link );
 			}
 			return apply_filters( 'document_permalink', $link, $document );
 		}

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -16,21 +16,21 @@ class WP_Document_Revisions {
 	 *
 	 * @var Object $instance
 	 */
-	static $instance;
+	public static $instance;
 
 	/**
 	 * Length of feed key
 	 *
 	 * @var Int $key_legth
 	 */
-	static $key_length = 32;
+	public static $key_length = 32;
 
 	/**
 	 * User meta key used auth feeds
 	 *
 	 * @var String $meta_key
 	 */
-	static $meta_key   = 'document_revisions_feed_key';
+	public static $meta_key   = 'document_revisions_feed_key';
 
 	/**
 	 * The plugin version
@@ -44,7 +44,7 @@ class WP_Document_Revisions {
 	 *
 	 * @since 0.5
 	 */
-	function __construct() {
+	public function __construct() {
 
 		self::$instance = &$this;
 
@@ -111,7 +111,7 @@ class WP_Document_Revisions {
 	 *
 	 * @return void
 	 */
-	function activation_hook() {
+	public function activation_hook() {
 		$this->add_caps();
 		flush_rewrite_rules();
 	}
@@ -120,7 +120,7 @@ class WP_Document_Revisions {
 	 * Init i18n files
 	 * Must be done early on init because they need to be in place when register_cpt is called
 	 */
-	function i18n() {
+	public function i18n() {
 		load_plugin_textdomain( 'wp-document-revisions', false, plugin_basename( dirname( __FILE__ ) ) . '/languages/' );
 	}
 
@@ -130,7 +130,7 @@ class WP_Document_Revisions {
 	 *
 	 * @since 0.5
 	 */
-	function admin_init() {
+	public function admin_init() {
 
 		// only fire on admin + escape hatch to prevent fatal errors
 		if ( ! is_admin() || class_exists( 'Document_Revisions_Admin' ) ) {
@@ -147,7 +147,7 @@ class WP_Document_Revisions {
 	 *
 	 * @since 0.5
 	 */
-	function register_cpt() {
+	public function register_cpt() {
 
 		$labels = array(
 			'name'               => _x( 'Documents', 'post type general name', 'wp-document-revisions' ),
@@ -193,7 +193,7 @@ class WP_Document_Revisions {
 	 *
 	 * @since 0.5
 	 */
-	function register_ct() {
+	public function register_ct() {
 
 		$labels = array(
 			'name'              => _x( 'Workflow States', 'taxonomy general name', 'wp-document-revisions' ),
@@ -230,7 +230,7 @@ class WP_Document_Revisions {
 	 * @since 0.5
 	 * @return unknown
 	 */
-	function initialize_workflow_states() {
+	public function initialize_workflow_states() {
 
 		$terms = get_terms(
 			'workflow_state', array(
@@ -268,7 +268,7 @@ class WP_Document_Revisions {
 	 * @param object $document (optional) post object
 	 * @return object all attached uploads
 	 */
-	function get_attachments( $document = '' ) {
+	public function get_attachments( $document = '' ) {
 
 		if ( '' === $document ) {
 			global $post;
@@ -317,7 +317,7 @@ class WP_Document_Revisions {
 	 * @param object|int $document the post object or postID
 	 * @return bool|string false if no lock, user's display name if locked
 	 */
-	function get_document_lock( $document ) {
+	public function get_document_lock( $document ) {
 
 		if ( ! is_object( $document ) ) {
 			$document = get_post( $document );
@@ -354,7 +354,7 @@ class WP_Document_Revisions {
 	 * @param string $file URL, path, or filename to file
 	 * @return string extension
 	 */
-	function get_extension( $file ) {
+	public function get_extension( $file ) {
 
 		$extension = '.' . pathinfo( $file, PATHINFO_EXTENSION );
 
@@ -375,7 +375,7 @@ class WP_Document_Revisions {
 	 * @param object|int $document_or_attachment document or attachment
 	 * @return string the extension to the latest revision
 	 */
-	function get_file_type( $document_or_attachment = '' ) {
+	public function get_file_type( $document_or_attachment = '' ) {
 
 		if ( '' === $document_or_attachment ) {
 			global $post;
@@ -418,7 +418,7 @@ class WP_Document_Revisions {
 	 *
 	 * @since 0.5
 	 */
-	function inject_rules() {
+	public function inject_rules() {
 
 		global $wp_rewrite;
 		$wp_rewrite->add_rewrite_tag( '%document%', '([^.]+)\.[A-Za-z0-9]{3,4}?', 'document=' );
@@ -433,7 +433,7 @@ class WP_Document_Revisions {
 	 * @param Array $rules rewrite rules
 	 * @return Array rewrite rules
 	 */
-	function revision_rewrite( $rules ) {
+	public function revision_rewrite( $rules ) {
 
 		$slug = $this->document_slug();
 
@@ -465,7 +465,7 @@ class WP_Document_Revisions {
 	 * @param array $vars the query vars
 	 * @return array the modified query vars
 	 */
-	function add_query_var( $vars ) {
+	public function add_query_var( $vars ) {
 		$vars[] = 'revision';
 		$vars[] = 'document';
 		return $vars;
@@ -482,7 +482,7 @@ class WP_Document_Revisions {
 	 * @param String $sample (optional) not used
 	 * @return string the real permalink
 	 */
-	function permalink( $link, $document, $leavename, $sample = '' ) {
+	public function permalink( $link, $document, $leavename, $sample = '' ) {
 
 		global $wp_rewrite;
 		$revision_num = false;
@@ -532,7 +532,7 @@ class WP_Document_Revisions {
 	 * @param int    $id Post ID
 	 * @return unknown
 	 */
-	function sample_permalink_html_filter( $html, $id ) {
+	public function sample_permalink_html_filter( $html, $id ) {
 
 		$document = get_post( $id );
 
@@ -563,7 +563,7 @@ class WP_Document_Revisions {
 	 * @param int $post_id the post ID
 	 * @return array array of post objects
 	 */
-	function get_revisions( $post_id ) {
+	public function get_revisions( $post_id ) {
 
 		// Revision authors are actually shifted by one
 		// This moves each revision author up one, and then uses the post_author as the initial revision
@@ -624,7 +624,7 @@ class WP_Document_Revisions {
 	 * @param bool $feed (optional) whether this is a feed
 	 * @return obj|bool the WP_Query object, false on failure
 	 */
-	function get_revision_query( $post_id, $feed = false ) {
+	public function get_revision_query( $post_id, $feed = false ) {
 
 		$posts = $this->get_revisions( $post_id );
 
@@ -649,7 +649,7 @@ class WP_Document_Revisions {
 	 * @param int $post_id the parent post id
 	 * @return array array of revisions
 	 */
-	function get_revision_indices( $post_id ) {
+	public function get_revision_indices( $post_id ) {
 
 		$cache = wp_cache_get( $post_id, 'document_revision_indices' );
 		if ( $cache ) {
@@ -685,7 +685,7 @@ class WP_Document_Revisions {
 	 * @param int $revision_id the revision ID
 	 * @return int revision number
 	 */
-	function get_revision_number( $revision_id ) {
+	public function get_revision_number( $revision_id ) {
 
 		$revision = get_post( $revision_id );
 
@@ -708,7 +708,7 @@ class WP_Document_Revisions {
 	 * @param int $post_id the ID of the parent post
 	 * @return int the ID of the revision
 	 */
-	function get_revision_id( $revision_num, $post_id ) {
+	public function get_revision_id( $revision_num, $post_id ) {
 
 		$index = $this->get_revision_indices( $post_id );
 
@@ -724,7 +724,7 @@ class WP_Document_Revisions {
 	 * @param String $template the requested template
 	 * @return String the resolved template
 	 */
-	function serve_file( $template ) {
+	public function serve_file( $template ) {
 		global $post;
 		global $wp_query;
 		global $wp;
@@ -877,7 +877,7 @@ class WP_Document_Revisions {
 	 * @param bool|int $version version of the document being served, if any
 	 * @return unknown
 	 */
-	function serve_document_auth( $default, $post, $version ) {
+	public function serve_document_auth( $default, $post, $version ) {
 
 		// public file, not a revision, no need to go any further
 		// note: non-authenticated users only have the "read" cap, so can't auth via read_document
@@ -906,7 +906,7 @@ class WP_Document_Revisions {
 	 * @param Int $id the post ID
 	 * @return unknown
 	 */
-	function get_latest_version( $id ) {
+	public function get_latest_version( $id ) {
 		_deprecated_function( __FUNCTION__, '1.0.3 of WP Document Revisions', 'get_latest_version' );
 		return $this->get_latest_revision( $id );
 	}
@@ -918,7 +918,7 @@ class WP_Document_Revisions {
 	 * @param Int $post_id the post id
 	 * @return object latest revision object
 	 */
-	function get_latest_revision( $post_id ) {
+	public function get_latest_revision( $post_id ) {
 
 		if ( is_object( $post_id ) ) {
 			$post_id = $post_id->ID;
@@ -956,7 +956,7 @@ class WP_Document_Revisions {
 	 * @param Int $id the post ID
 	 * @return String the revision URL
 	 */
-	function get_latest_version_url( $id ) {
+	public function get_latest_version_url( $id ) {
 		_deprecated_function( __FUNCTION__, '1.0.3 of WP Document Revisions', 'get_latest_revision_url' );
 		return $this->get_latest_revision_url( $id );
 	}
@@ -969,7 +969,7 @@ class WP_Document_Revisions {
 	 * @param int $id post ID
 	 * @return string|bool URL to revision or false if no attachment
 	 */
-	function get_latest_revision_url( $id ) {
+	public function get_latest_revision_url( $id ) {
 
 		$latest = $this->get_latest_revision( $id );
 
@@ -992,7 +992,7 @@ class WP_Document_Revisions {
 	 * @since 0.5
 	 * @return string path to document
 	 */
-	function document_upload_dir() {
+	public function document_upload_dir() {
 
 		global $wpdb;
 
@@ -1027,7 +1027,7 @@ class WP_Document_Revisions {
 	 *
 	 * @return unknown
 	 */
-	function document_slug() {
+	public function document_slug() {
 
 		$slug = get_site_option( 'document_slug' );
 
@@ -1047,7 +1047,7 @@ class WP_Document_Revisions {
 	 * @param array $dir defaults passed from WP
 	 * @return array $dir modified directory
 	 */
-	function document_upload_dir_filter( $dir ) {
+	public function document_upload_dir_filter( $dir ) {
 
 		if ( ! $this->verify_post_type() ) {
 			return $dir;
@@ -1071,7 +1071,7 @@ class WP_Document_Revisions {
 	 * @param int    $id attachment ID
 	 * @return string empty string
 	 */
-	function attachment_link_filter( $link, $id ) {
+	public function attachment_link_filter( $link, $id ) {
 
 		if ( ! $this->verify_post_type( $id ) ) {
 			return $link;
@@ -1088,7 +1088,7 @@ class WP_Document_Revisions {
 	 * @param array $file file data from WP
 	 * @return array $file file with new filename
 	 */
-	function filename_rewrite( $file ) {
+	public function filename_rewrite( $file ) {
 
 		// verify this is a document
 		if ( ! isset( $_POST['post_id'] ) || ! $this->verify_post_type( $_POST['post_id'] ) ) {
@@ -1112,7 +1112,7 @@ class WP_Document_Revisions {
 	 * @param array $file file object from WP
 	 * @return array modified file array
 	 */
-	function rewrite_file_url( $file ) {
+	public function rewrite_file_url( $file ) {
 
 		// verify that this is a document
 		if ( ! isset( $_POST['post_id'] ) || ! $this->verify_post_type( $_POST['post_id'] ) ) {
@@ -1134,7 +1134,7 @@ class WP_Document_Revisions {
 	 * @since 0.5
 	 * @return bool true if document, false if not
 	 */
-	function verify_post_type( $documentish = false ) {
+	public function verify_post_type( $documentish = false ) {
 		global $wp_query;
 
 		if ( false === $documentish ) {
@@ -1177,7 +1177,7 @@ class WP_Document_Revisions {
 	 *
 	 * @param int $post_id the post ID
 	 */
-	function clear_cache( $post_id ) {
+	public function clear_cache( $post_id ) {
 		wp_cache_delete( $post_id, 'document_post_type' );
 		wp_cache_delete( $post_id, 'document_revision_indices' );
 		wp_cache_delete( $post_id, 'document_revisions' );
@@ -1189,7 +1189,7 @@ class WP_Document_Revisions {
 	 *
 	 * @since 0.5
 	 */
-	function do_feed_revision_log() {
+	public function do_feed_revision_log() {
 
 		// because we're in function scope, pass $post as a global
 		global $post;
@@ -1213,7 +1213,7 @@ class WP_Document_Revisions {
 	 * @param string $default the original feed
 	 * @return string the slug for our feed
 	 */
-	function hijack_feed( $default ) {
+	public function hijack_feed( $default ) {
 
 		if ( ! $this->verify_post_type() || ! apply_filters( 'document_custom_feed', true ) ) {
 			return $default;
@@ -1231,7 +1231,7 @@ class WP_Document_Revisions {
 	 *
 	 * @since 0.5
 	 */
-	function revision_feed_auth() {
+	public function revision_feed_auth() {
 
 		if ( ! $this->verify_post_type() || ! apply_filters( 'document_verify_feed_key', true ) ) {
 			return;
@@ -1250,7 +1250,7 @@ class WP_Document_Revisions {
 	 * @since 0.5
 	 * @return bool
 	 */
-	function validate_feed_key() {
+	public function validate_feed_key() {
 
 		global $wpdb;
 
@@ -1282,7 +1282,7 @@ class WP_Document_Revisions {
 	 * @since 0.5
 	 * @param bool $send_notice (optional) whether or not to send an e-mail to the former lock owner
 	 */
-	function override_lock( $send_notice = true ) {
+	public function override_lock( $send_notice = true ) {
 
 		check_ajax_referer( 'wp-document-revisions', 'nonce' );
 
@@ -1324,7 +1324,7 @@ class WP_Document_Revisions {
 	 * @param int $current_user_id id of user overriding lock
 	 * @return bool true on sucess, false on fail
 	 */
-	function send_override_notice( $post_id, $owner_id, $current_user_id ) {
+	public function send_override_notice( $post_id, $owner_id, $current_user_id ) {
 
 		// get lock owner's details
 		$lock_owner = get_userdata( $owner_id );
@@ -1364,7 +1364,7 @@ class WP_Document_Revisions {
 
 	 * @since 1.0
 	 */
-	function add_caps() {
+	public function add_caps() {
 		global $wp_roles;
 		if ( ! isset( $wp_roles ) ) {
 			// @codingStandardsIgnoreLine
@@ -1478,7 +1478,7 @@ class WP_Document_Revisions {
 	 * @param string $prepend the sprintf formatted string to prepend to the title
 	 * @return string just the string
 	 */
-	function no_title_prepend( $prepend ) {
+	public function no_title_prepend( $prepend ) {
 
 		if ( ! $this->verify_post_type() ) {
 			return $prepend;
@@ -1496,7 +1496,7 @@ class WP_Document_Revisions {
 	 * @param string $title the title
 	 * @return string the title possibly with the revision number
 	 */
-	function add_revision_num_to_title( $title ) {
+	public function add_revision_num_to_title( $title ) {
 		global $post;
 
 		// verify post type
@@ -1537,7 +1537,7 @@ class WP_Document_Revisions {
 	 * @param string $content the post content
 	 * @return string either the original content or none
 	 */
-	function content_filter( $content ) {
+	public function content_filter( $content ) {
 
 		if ( ! $this->verify_post_type() ) {
 			return $content;
@@ -1558,7 +1558,7 @@ class WP_Document_Revisions {
 	 *
 	 * @return unknown
 	 */
-	function edit_flow_support() {
+	public function edit_flow_support() {
 
 		global $edit_flow;
 
@@ -1600,7 +1600,7 @@ class WP_Document_Revisions {
 	 *
 	 * @return bool true if workflow states are on, otherwise false
 	 */
-	function use_workflow_states() {
+	public function use_workflow_states() {
 
 		return apply_filters( 'document_use_workflow_states', true );
 
@@ -1610,7 +1610,7 @@ class WP_Document_Revisions {
 	/**
 	 * Removes front-end hooks to add workflow state support
 	 */
-	function disable_workflow_states() {
+	public function disable_workflow_states() {
 
 		if ( $this->use_workflow_states() ) {
 			return;
@@ -1631,7 +1631,7 @@ class WP_Document_Revisions {
 	 * @param unknown $return_attachments (optional)
 	 * @return array an array of post objects
 	 */
-	function get_documents( $args = array(), $return_attachments = false ) {
+	public function get_documents( $args = array(), $return_attachments = false ) {
 
 		$args = (array) $args;
 		$args['post_type'] = 'document';
@@ -1673,7 +1673,7 @@ class WP_Document_Revisions {
 	 * @param int    $post_id the attachment ID
 	 * @return string the modified URL
 	 */
-	function attachment_url_filter( $url, $post_id ) {
+	public function attachment_url_filter( $url, $post_id ) {
 
 		// not an attached attachment
 		if ( ! $this->verify_post_type( $post_id ) ) {
@@ -1715,7 +1715,7 @@ class WP_Document_Revisions {
 	 * @param string $url the permalink
 	 * @return string the modified permalink
 	 */
-	function wamp_document_path_filter( $url ) {
+	public function wamp_document_path_filter( $url ) {
 		$url = preg_replace( '|^([a-z]{1}):|i', '', $url ); // Strip out windows drive letter if it's there.
 		return str_replace( '\\', '/', $url ); // Windows path sanitization
 	}
@@ -1729,7 +1729,7 @@ class WP_Document_Revisions {
 	 * @param Array  $terms the terms to filter
 	 * @param Object $taxonomy the taxonomy object
 	 */
-	function term_count_cb( $terms, $taxonomy ) {
+	public function term_count_cb( $terms, $taxonomy ) {
 		add_filter( 'query', array( &$this, 'term_count_query_filter' ) );
 		_update_post_term_count( $terms, $taxonomy );
 		remove_filter( 'query', array( &$this, 'term_count_query_filter' ) );
@@ -1744,7 +1744,7 @@ class WP_Document_Revisions {
 	 * @param Object $query the query object
 	 * @return String the modified query
 	 */
-	function term_count_query_filter( $query ) {
+	public function term_count_query_filter( $query ) {
 		return str_replace( "post_status = 'publish'", "post_status != 'trash'", $query );
 	}
 
@@ -1755,7 +1755,7 @@ class WP_Document_Revisions {
 	 *
 	 * @since 1.2.1
 	 */
-	function register_term_count_cb() {
+	public function register_term_count_cb() {
 
 		$taxs = get_taxonomies(
 			array(
@@ -1781,7 +1781,7 @@ class WP_Document_Revisions {
 	 * @param Object $request the request object
 	 * @return String the redirect URL without the trailing slash
 	 */
-	function redirect_canonical_filter( $redirect, $request ) {
+	public function redirect_canonical_filter( $redirect, $request ) {
 
 		if ( ! $this->verify_post_type() ) {
 			return $redirect;
@@ -1803,7 +1803,7 @@ class WP_Document_Revisions {
 	 * @param string $size the size requested
 	 * @return array the image array returned from image_downsize()
 	 */
-	function image_downsize( $false, $id, $size ) {
+	public function image_downsize( $false, $id, $size ) {
 
 		if ( ! $this->verify_post_type( $id ) ) {
 			return false;
@@ -1837,7 +1837,7 @@ class WP_Document_Revisions {
 	 * @param Object $wp The global WP object
 	 * @return the WP global object
 	 */
-	function ie_cache_fix( $wp ) {
+	public function ie_cache_fix( $wp ) {
 
 		// SSL check
 		if ( ! is_ssl() ) {

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -60,7 +60,7 @@ class WP_Document_Revisions {
 		add_action( 'wp_loaded', array( &$this, 'register_term_count_cb' ), 100, 1 );
 
 		// rewrites and permalinks
-		add_filter( 'rewrite_rules_array' , array( &$this, 'revision_rewrite' ) );
+		add_filter( 'rewrite_rules_array', array( &$this, 'revision_rewrite' ) );
 		add_filter( 'init', array( &$this, 'inject_rules' ) );
 		add_action( 'post_type_link', array( &$this, 'permalink' ), 10, 4 );
 		add_action( 'post_link', array( &$this, 'permalink' ), 10, 4 );
@@ -515,7 +515,7 @@ class WP_Document_Revisions {
 		$timestamp = strtotime( $document->post_date );
 		$link = home_url() . '/' . $this->document_slug() . '/' . date( 'Y', $timestamp ) . '/' . date( 'm', $timestamp ) . '/';
 		$link .= ( $leavename ) ? '%document%' : $document->post_name;
-		$link .= $extension ;
+		$link .= $extension;
 
 		$link = apply_filters( 'document_permalink', $link, $document );
 
@@ -779,7 +779,7 @@ class WP_Document_Revisions {
 		// note: authentication is happeneing via a hook here to allow shortcircuiting
 		if ( ! apply_filters( 'serve_document_auth', true, $post, $version ) ) {
 			wp_die(
-				esc_html__( 'You are not authorized to access that file.', 'wp-document-revisions' ) , null, array(
+				esc_html__( 'You are not authorized to access that file.', 'wp-document-revisions' ), null, array(
 					'response' => 403,
 				)
 			);
@@ -845,8 +845,8 @@ class WP_Document_Revisions {
 		$modified_timestamp = strtotime( $last_modified );
 
 		if ( ( $client_last_modified && $client_etag )
-			? ( ( $client_modified_timestamp >= $modified_timestamp) && ( $client_etag === $etag ) )
-			: ( ( $client_modified_timestamp >= $modified_timestamp) || ( $client_etag === $etag ) )
+			? ( ( $client_modified_timestamp >= $modified_timestamp ) && ( $client_etag === $etag ) )
+			: ( ( $client_modified_timestamp >= $modified_timestamp ) || ( $client_etag === $etag ) )
 		) {
 			status_header( 304 );
 			return;
@@ -1288,7 +1288,7 @@ class WP_Document_Revisions {
 
 		// verify current user can edit
 		// consider a specific permission check here
-		if ( ! $_POST['post_id'] || ! current_user_can( 'edit_post' , $_POST['post_id'] ) || ! current_user_can( 'override_document_lock' ) ) {
+		if ( ! $_POST['post_id'] || ! current_user_can( 'edit_post', $_POST['post_id'] ) || ! current_user_can( 'override_document_lock' ) ) {
 			wp_die( esc_html__( 'Not authorized', 'wp-document-revisions' ) );
 		}
 
@@ -1344,7 +1344,7 @@ class WP_Document_Revisions {
 		// translators: %s is the user's name
 		$message = sprintf( __( 'Dear %s:', 'wp-document-revisions' ), $lock_owner->display_name ) . "\n\n";
 		// translators: %1$s is the overriding user, %2$s is the user's email, %3$s is the document title, %4$s is the document URL
-		$message .= sprintf( __( '%1$s (%2$s), has overridden your lock on the document %3$s (%4$s).', 'wp-document-revisions' ), $current_user->display_name,  $current_user->user_email, $document->post_title, get_permalink( $document->ID ) ) . "\n\n";
+		$message .= sprintf( __( '%1$s (%2$s), has overridden your lock on the document %3$s (%4$s).', 'wp-document-revisions' ), $current_user->display_name, $current_user->user_email, $document->post_title, get_permalink( $document->ID ) ) . "\n\n";
 		$message .= __( 'Any changes you have made will be lost.', 'wp-document-revisions' ) . "\n\n";
 		// translators: %s is the blog name
 		$message .= sprintf( __( '- The %s Team', 'wp-document-revisions' ), get_bloginfo( 'name' ) );
@@ -1353,7 +1353,7 @@ class WP_Document_Revisions {
 		apply_filters( 'document_lock_override_email', $message, $post_id, $current_user_id, $lock_owner );
 
 		// send mail
-		return wp_mail( $lock_owner->user_email, $subject , $message );
+		return wp_mail( $lock_owner->user_email, $subject, $message );
 
 	}
 
@@ -1512,7 +1512,7 @@ class WP_Document_Revisions {
 				$title = sprintf( __( '%s - Latest Revision', 'wp-document-revisions' ), $title );
 			}
 
-			return apply_filters( 'document_title',  $title );
+			return apply_filters( 'document_title', $title );
 
 		}
 

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -7,6 +7,8 @@
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
 		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged" />
 		<exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification" />
+		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
+		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning" />
 	</rule>
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -13,6 +13,10 @@
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />
 
+	<rule ref="Generic.Files.OneClassPerFile">
+		<exclude-pattern>includes/class-wp-document-revisions-front-end.php</exclude-pattern>
+	</rule>
+
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/vendor/autoload.php</exclude-pattern>
 </ruleset>

--- a/tests/class-test-wp-document-revisions-front-end.php
+++ b/tests/class-test-wp-document-revisions-front-end.php
@@ -15,7 +15,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	/**
 	 * SetUp initial settings
 	 */
-	function setUp() {
+	public function setUp() {
 
 		parent::setUp();
 
@@ -35,7 +35,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	/**
 	 * Break down for next test
 	 */
-	function tearDown() {
+	public function tearDown() {
 
 		_destroy_uploads();
 		parent::tearDown();
@@ -45,7 +45,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	/**
 	 * Verify joe public can't access a list of revisions
 	 */
-	function test_revisions_shortcode_unauthed() {
+	public function test_revisions_shortcode_unauthed() {
 
 		$tdr = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_revise_document();
@@ -59,7 +59,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	/**
 	 * Verify auth'd user can view revision shortcode and can truncate proper count
 	 */
-	function test_revisions_shortcode() {
+	public function test_revisions_shortcode() {
 
 		$tdr = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_revise_document();
@@ -77,7 +77,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	/**
 	 * Tests the document_revisions shortcode with a number=1 limit
 	 */
-	function test_revision_shortcode_limit() {
+	public function test_revision_shortcode_limit() {
 
 		$tdr = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_revise_document();
@@ -95,7 +95,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	/**
 	 * Tests the documents shortcode
 	 */
-	function test_document_shortcode() {
+	public function test_document_shortcode() {
 
 		$tdr = new Test_WP_Document_Revisions();
 
@@ -111,7 +111,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	/**
 	 * Tests the documents shortcode with a workflow state filter
 	 */
-	function test_document_shortcode_wfs_filter() {
+	public function test_document_shortcode_wfs_filter() {
 
 		$tdr = new Test_WP_Document_Revisions();
 
@@ -139,7 +139,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	/**
 	 * Test documetn shortcode with a post_meta filter
 	 */
-	function test_document_shortcode_post_meta_filter() {
+	public function test_document_shortcode_post_meta_filter() {
 
 		$tdr = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_add_document(); // add a doc
@@ -160,7 +160,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	/**
 	 * Tests the public get_documents function
 	 */
-	function test_get_documents() {
+	public function test_get_documents() {
 
 		$tdr = new Test_WP_Document_Revisions();
 
@@ -178,7 +178,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	/**
 	 * Tests that get_documents returns attachments when asked
 	 */
-	function test_get_documents_returns_attachments() {
+	public function test_get_documents_returns_attachments() {
 
 		$tdr = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_add_document(); // add a doc
@@ -195,7 +195,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	/**
 	 * Tests that get_documents properly filters when asked
 	 */
-	function test_get_documents_filter() {
+	public function test_get_documents_filter() {
 
 		$tdr = new Test_WP_Document_Revisions();
 
@@ -220,7 +220,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	/**
 	 * Tests the get_revisions function
 	 */
-	function test_get_document_revisions() {
+	public function test_get_document_revisions() {
 		$tdr = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_revise_document(); // add a doc
 		$this->assertCount( 2, get_document_revisions( $doc_id ) );

--- a/tests/class-test-wp-document-revisions-rewrites.php
+++ b/tests/class-test-wp-document-revisions-rewrites.php
@@ -14,7 +14,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * SetUp initial settings
 	 */
-	function setUp() {
+	public function setUp() {
 
 		parent::setUp();
 
@@ -38,7 +38,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Break down for next test
 	 */
-	function tearDown() {
+	public function tearDown() {
 		global $wp_rewrite;
 		$wp_rewrite->set_permalink_structure( '' );
 
@@ -54,7 +54,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	 * @param string $file relative path of expected file
 	 * @param string $msg message describing failure
 	 */
-	function verify_download( $url = null, $file = null, $msg = null ) {
+	public function verify_download( $url = null, $file = null, $msg = null ) {
 
 		if ( ! $url ) {
 			return;
@@ -86,7 +86,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	 * @param string $file relative path of expected file
 	 * @param string $msg message describing failure
 	 */
-	function verify_cant_download( $url = null, $file = null, $msg = null ) {
+	public function verify_cant_download( $url = null, $file = null, $msg = null ) {
 
 		if ( ! $url ) {
 			return;
@@ -113,7 +113,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Can the public access a public file? (yes)
 	 */
-	function test_public_document() {
+	public function test_public_document() {
 		global $wpdr;
 
 		// make new public document
@@ -133,7 +133,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Can the public access a private file? (no)
 	 */
-	function test_private_document_as_unauthenticated() {
+	public function test_private_document_as_unauthenticated() {
 
 		// make new private document
 		$tdr = new Test_WP_Document_Revisions();
@@ -154,7 +154,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Can a contributor access a public file? (no)
 	 */
-	function test_private_document_as_contributor() {
+	public function test_private_document_as_contributor() {
 
 		// make new private document
 		$tdr = new Test_WP_Document_Revisions();
@@ -174,7 +174,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Can an admin access a private file? (yes)
 	 */
-	function test_private_document_as_admin() {
+	public function test_private_document_as_admin() {
 
 		// make new private document
 		$tdr = new Test_WP_Document_Revisions();
@@ -194,7 +194,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Can the public access a document revision? (no)
 	 */
-	function test_document_revision_as_a_unauthenticated() {
+	public function test_document_revision_as_a_unauthenticated() {
 		global $wpdr;
 
 		// make new public, revised document
@@ -219,7 +219,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Can an admin access a document revision? (yes)
 	 */
-	function test_document_revision_as_admin() {
+	public function test_document_revision_as_admin() {
 
 		global $wpdr;
 
@@ -245,7 +245,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Do we serve the latest version of a document?
 	 */
-	function test_revised_document() {
+	public function test_revised_document() {
 
 		global $wpdr;
 
@@ -263,7 +263,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Does the document archive work?
 	 */
-	function test_archive() {
+	public function test_archive() {
 		global $wpdr;
 		$tdr = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_add_document();
@@ -276,7 +276,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Does get_permalink generate the right permalink?
 	 */
-	function test_permalink() {
+	public function test_permalink() {
 
 		global $wpdr;
 		$tdr = new Test_WP_Document_Revisions();
@@ -291,7 +291,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Test get_permalink() on a revision
 	 */
-	function test_revision_permalink() {
+	public function test_revision_permalink() {
 
 		global $wpdr;
 		$tdr = new Test_WP_Document_Revisions();
@@ -311,7 +311,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	 * @return string the content returned
 	 * @throws Exception If there's an error.
 	 */
-	function simulate_feed( $url = null ) {
+	public function simulate_feed( $url = null ) {
 		if ( ! $url ) {
 			return '';
 		}
@@ -342,7 +342,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Can the public access a revision log feed?
 	 */
-	function test_feed_as_unauthenticated() {
+	public function test_feed_as_unauthenticated() {
 
 		global $wpdr;
 
@@ -361,7 +361,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Can a user with the proper feed key access a feed?
 	 */
-	function test_feed_as_authorized() {
+	public function test_feed_as_authorized() {
 
 		global $wpdr;
 
@@ -389,7 +389,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	/**
 	 * Tests that changing the document slug is reflected in permalinks
 	 */
-	function test_document_slug() {
+	public function test_document_slug() {
 
 		global $wp_rewrite;
 		$tdr = new Test_WP_Document_Revisions();

--- a/tests/class-test-wp-document-revisions-rewrites.php
+++ b/tests/class-test-wp-document-revisions-rewrites.php
@@ -329,7 +329,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 		ob_start();
 		global $post;
 		try {
-			@require( dirname( __DIR__ ) . '/includes/revision-feed.php' );
+			@require dirname( __DIR__ ) . '/includes/revision-feed.php';
 			$content = ob_get_clean();
 		} catch ( Exception $e ) {
 			$content = ob_get_clean();

--- a/tests/class-test-wp-document-revisions.php
+++ b/tests/class-test-wp-document-revisions.php
@@ -28,7 +28,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	/**
 	 * Setup Initial Testing Environment
 	 */
-	function setUp() {
+	public function setUp() {
 
 		global $wpdr;
 
@@ -55,14 +55,14 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	/**
 	 * If called via rewrites tests
 	 */
-	function __construct() {
+	public function __construct() {
 		$this->setUp();
 	}
 
 	/**
 	 * Make sure plugin is activated
 	 */
-	function test_activated() {
+	public function test_activated() {
 
 		$this->assertTrue( class_exists( 'WP_Document_Revisions' ), 'Document_Revisions class not defined' );
 
@@ -72,7 +72,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	/**
 	 * Post type is properly registered
 	 */
-	function test_post_type_exists() {
+	public function test_post_type_exists() {
 
 		$this->assertTrue( post_type_exists( 'document' ), 'Document post type does not exist' );
 
@@ -82,7 +82,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	/**
 	 * Workflow states exists and are initialized
 	 */
-	function test_workflow_states_exist() {
+	public function test_workflow_states_exist() {
 
 		$terms = get_terms(
 			'workflow_state', array(
@@ -102,7 +102,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	 * @param string $file relative URL to file to "upload"
 	 * @return int the attachment ID
 	 */
-	function spoof_upload( $post_id, $file ) {
+	public function spoof_upload( $post_id, $file ) {
 
 		global $wpdr;
 		$file = dirname( __FILE__ ) . '/' . $file;
@@ -148,7 +148,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	 *
 	 * @return int document id
 	 */
-	function test_add_document() {
+	public function test_add_document() {
 		global $wpdr;
 		global $wpdb;
 
@@ -206,7 +206,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	 *
 	 * @return int the revision ID
 	 */
-	function test_revise_document() {
+	public function test_revise_document() {
 
 		$doc_id = self::test_add_document();
 
@@ -235,7 +235,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	 * @param string $file relative url to file
 	 * @param string $msg message to display on failure
 	 */
-	function verify_attachment_matches_file( $post_id = null, $file = null, $msg = null ) {
+	public function verify_attachment_matches_file( $post_id = null, $file = null, $msg = null ) {
 
 		if ( ! $post_id ) {
 			return;
@@ -252,7 +252,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	/**
 	 * Validate teh get_attachments function are few different ways
 	 */
-	function test_get_attachments() {
+	public function test_get_attachments() {
 
 		global $wpdr;
 
@@ -284,7 +284,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	/**
 	 * Verify the get_file_Type function works
 	 */
-	function test_file_type() {
+	public function test_file_type() {
 
 		global $wpdr;
 
@@ -304,7 +304,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	/**
 	 * Make sure get_revisions() works
 	 */
-	function test_get_revisions() {
+	public function test_get_revisions() {
 		global $wpdr;
 
 		$doc_id = $this->test_revise_document();
@@ -317,7 +317,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	/**
 	 * Tets get_revision_number()
 	 */
-	function test_get_revision_number() {
+	public function test_get_revision_number() {
 
 		global $wpdr;
 
@@ -333,7 +333,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	/**
 	 * Tests varify_post_type() with the various ways used throughout
 	 */
-	function test_verify_post_type() {
+	public function test_verify_post_type() {
 		global $wpdr;
 
 		$doc_id = $this->test_add_document();

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -46,7 +46,7 @@ require_once dirname( __FILE__ ) . '/includes/class-wp-document-revisions.php';
 // $wpdr is a global reference to the class.
 global $wpdr;
 $wpdr = new WP_Document_Revisions();
-include_once dirname( __FILE__ ) . '/includes/template-functions.php';
+require_once dirname( __FILE__ ) . '/includes/template-functions.php';
 
 // Activation hooks must be relative to the main plugin file
 register_activation_hook( __FILE__, array( &$wpdr, 'activation_hook' ) );


### PR DESCRIPTION
[WPCS 0.14.0 was released a few days ago](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/0.14.0) and several new rules are applied.