### PR TITLE
Provide a way to filter or skip mime type detection

### DIFF
--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -791,18 +791,6 @@ class WP_Document_Revisions {
 		// We may override this later.
 		status_header( 200 );
 
-		// rest inspired by wp-includes/ms-files.php.
-		$mime = wp_check_filetype( $file );
-		if ( false === $mime['type'] && function_exists( 'mime_content_type' ) ) {
-			$mime['type'] = mime_content_type( $file );
-		}
-
-		if ( $mime['type'] ) {
-			$mimetype = $mime['type'];
-		} else {
-			$mimetype = 'image/' . substr( $file, strrpos( $file, '.' ) + 1 );
-		}
-
 		// fake the filename
 		$filename = $post->post_name;
 		$filename .= ( '' === $version ) ? '' : __( '-revision-', 'wp-document-revisions' ) . $version;
@@ -818,8 +806,37 @@ class WP_Document_Revisions {
 		$disposition = ( apply_filters( 'document_content_disposition_inline', true ) ) ? 'inline' : 'attachment';
 		@header( 'Content-Disposition: ' . $disposition . '; filename="' . $filename . '"' );
 
-		// filetype and length
-		@header( 'Content-Type: ' . $mimetype ); // always send this
+		/**
+		 * Filters the MIME type for a file before it is processed by WP Document Revisions.
+		 *
+		 * If filtered to `false`, no `Content-Type` header will be set by the plugin.
+		 *
+		 * If filtered to a string, that value will be set for the `Content-Type` header.
+		 *
+		 * @param null|bool|string $mimetype The MIME type for a given file.
+		 * @param string           $file     The file being served.
+		 */
+		$mimetype = apply_filters( 'document_revisions_mimetype', null, $file );
+
+		if ( is_null( $mimetype ) ) {
+			// inspired by wp-includes/ms-files.php.
+			$mime = wp_check_filetype( $file );
+			if ( false === $mime['type'] && function_exists( 'mime_content_type' ) ) {
+				$mime['type'] = mime_content_type( $file );
+			}
+
+			if ( $mime['type'] ) {
+				$mimetype = $mime['type'];
+			} else {
+				$mimetype = 'image/' . substr( $file, strrpos( $file, '.' ) + 1 );
+			}
+		}
+
+		// Set the Content-Type header if a mimetype has been detected or provided.
+		if ( is_string( $mimetype ) ) {
+			@header( 'Content-Type: ' . $mimetype );
+		}
+
 		@header( 'Content-Length: ' . filesize( $file ) );
 
 		// modified


### PR DESCRIPTION
When using a plugin such as [S3 Uploads](https://github.com/humanmade/S3-Uploads), the AWS S3 SDK stream wrapper for PHP [does not include support](https://forums.aws.amazon.com/message.jspa?messageID=505342) for `mime_content_type`. When `mime_content_type()` fires on the S3 SDK stream resource, an error like `PHP Warning:  mime_content_type(): Failed identify data 0:invalid mode 00` appears. S3 Uploads instead provides a [replacement method](https://github.com/humanmade/S3-Uploads/blob/bcb0a70980bcb102c8705627601ed977bdf2c3c9/inc/class-s3-uploads-local-stream-wrapper.php#L78) for mime type detection. 

Additionally, in some server configurations it's possible that the `Content-Type` header set here does not make its way to the response and accounts instead for extra overhead.

To allow support for situations like this, it should be possible to filter the value of `$mimetype` before detection is attempted by WP Document Revisions.

When filtered to `false`, we skip the mime type detection all together. When filtered to a string, the content type header is sent.