### PR TITLE
Don't verify posts that don't exist

### DIFF
--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1169,6 +1169,11 @@ class WP_Document_Revisions {
 		}
 
 		$post = get_post( $documentish );
+
+		if ( ! $post ) {
+			return false;
+		}
+
 		$post_type = $post->post_type;
 
 		// if post is really an attachment or revision, look to the post's parent


### PR DESCRIPTION
If `0` is passed to `verify_post_type()` and a global post object is not available, then immediately return `false`.

This caused a warning when viewing the media library. Introduced in 54d017c33b815915253674b63d169c508a43277a 🎉 .