### PR TITLE
Fixes #111: Multisite issue with main site

### DIFF
--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1030,6 +1030,10 @@ class WP_Document_Revisions {
 
 		// make site specific on multisite
 		if ( is_multisite() && ! is_network_admin() ) {
+			if ( is_main_site() ) {
+				$dir = str_replace( '/sites/%site_id%', '', $dir );
+			}
+
 			$dir = str_replace( '%site_id%', $wpdb->blogid, $dir );
 		}
 


### PR DESCRIPTION
When using WP Document Revisions in a multisite installation, there were issues with the uploads folder setting when using the plugin both on the main site (usually site with ID = 1) and on other sub-sites. This pull request fixes that by removing the site-specific part for the main site.