### PR TITLE
For using Permalinks with changed directory

### DIFF
--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -408,7 +408,7 @@ class WP_Document_Revisions {
 			}
 		}
 
-		// although get_attached_file uses the standard directory, 
+		// although get_attached_file uses the standard directory,
 		// not used, so doesn't matter so no correction needed
 		return $this->get_extension( get_attached_file( $attachment->ID ) );
 
@@ -762,7 +762,7 @@ class WP_Document_Revisions {
 		// Used cached version of std directory, so cannot change within call, so replace it in the output
 		$std_dir = wp_get_upload_dir();
 		$doc_dir = $this->document_upload_dir();
-		if ( $std_dir['basedir'] != $doc_dir ) {
+		if ( $std_dir['basedir'] !== $doc_dir ) {
 			$file = str_replace( $std_dir['basedir'], $doc_dir, $file );
 		}
 

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -408,6 +408,8 @@ class WP_Document_Revisions {
 			}
 		}
 
+		// although get_attached_file uses the standard directory, 
+		// not used, so doesn't matter so no correction needed
 		return $this->get_extension( get_attached_file( $attachment->ID ) );
 
 	}
@@ -757,6 +759,12 @@ class WP_Document_Revisions {
 		$revision = get_post( $rev_post->post_content ); // @todo can this be simplified?
 
 		$file = get_attached_file( $revision->ID );
+		// Used cached version of std directory, so cannot change within call, so replace it in the output
+		$std_dir = wp_get_upload_dir();
+		$doc_dir = $this->document_upload_dir();
+		if ( $std_dir['basedir'] != $doc_dir ) {
+			$file = str_replace( $std_dir['basedir'], $doc_dir, $file );
+		}
 
 		// flip slashes for WAMP settups to prevent 404ing on the next line
 		$file = apply_filters( 'document_path', $file );


### PR DESCRIPTION
This is issue #116 (and possibly #82)

When using a permalink, the process serve_file uses get_attached_file which uses a cached version of the upload directory without direct reference to the specific post.
This gives the standard directory. If the user has defined a different directory then this is not used  - and the 404 results.