### PR TITLE
Create Edit link on document shortcode

### DIFF
--- a/css/style-front.css
+++ b/css/style-front.css
@@ -1,0 +1,4 @@
+.document-mod {
+	 opacity: 0.6;
+	 font-size: small;
+}

--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -1468,7 +1468,7 @@ class WP_Document_Revisions_Admin {
 			$format_string = __( '%1$s ago by %2$s [%3$s]', 'wp-document-revisions' );
 			?>
 			<li>
-				<a href="<?php echo esc_attr( $link ); ?>"><?php echo get_the_title( $document->ID ); ?></a><br />
+				<a href="<?php echo esc_attr( $link ); ?>"><?php echo esc_html( get_the_title( $document->ID ) ); ?></a><br />
 				<?php
 				printf(
 					esc_html( $format_string ),

--- a/includes/class-wp-document-revisions-front-end.php
+++ b/includes/class-wp-document-revisions-front-end.php
@@ -411,7 +411,7 @@ class Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 			$format_string = ( $instance['show_author'] ) ? __( '%1$s ago by %2$s', 'wp-document-revisions' ) : __( '%1$s ago', 'wp-document-revisions' );
 			?>
 			<li>
-				<a href="<?php echo esc_attr( $link ); ?>"><?php echo get_the_title( $document->ID ); ?></a><br />
+				<a href="<?php echo esc_attr( $link ); ?>"><?php echo esc_html( get_the_title( $document->ID ) ); ?></a><br />
 				<?php printf( esc_html( $format_string ), esc_html( human_time_diff( strtotime( $document->post_modified_gmt ) ) ), esc_html( get_the_author_meta( 'display_name', $document->post_author ) ) ); ?>
 			</li>
 			<?php

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -179,6 +179,20 @@ class WP_Document_Revisions {
 
 
 	/**
+	 * Set the default content directory name into cacle
+	 *
+	 * @return void
+	 *
+	 * @since 3.2
+	 */
+	function set_default_dir_cache() {
+		remove_filter( 'upload_dir', array( &$this, 'document_upload_dir_filter' ), 10 );
+		self::$wp_default_dir = wp_upload_dir();
+		add_filter( 'upload_dir', array( &$this, 'document_upload_dir_filter' ), 10 );
+	}
+
+
+	/**
 	 * Extends class with admin functions when in admin backend
 	 *
 	 * @since 0.5
@@ -250,9 +264,7 @@ class WP_Document_Revisions {
 
 		if ( empty( self::$wp_default_dir ) ) {
 			// Set the default upload directory cache
-			remove_filter( 'upload_dir', array( &$this, 'document_upload_dir_filter' ), 10 );
-			self::$wp_default_dir = wp_upload_dir();
-			add_filter( 'upload_dir', array( &$this, 'document_upload_dir_filter' ), 10 );
+			$this->set_default_dir_cache();
 		}
 
 		// Set Global for Document Image from Cookie doc_image (may be updated later)
@@ -842,6 +854,10 @@ class WP_Document_Revisions {
 		$file = get_attached_file( $revision->ID );
 		// Above used a cached version of std directory, so cannot change within call and may be wrong,
 		// so possibly replace it in the output
+		if ( empty( self::$wp_default_dir ) ) {
+			// Set the default upload directory cache
+			$this->set_default_dir_cache();
+		}
 		$std_dir = self::$wp_default_dir['basedir'];
 		$doc_dir = $this->document_upload_dir();
 		if ( $std_dir !== $doc_dir ) {
@@ -1127,6 +1143,10 @@ class WP_Document_Revisions {
 		// If no options set, default to normal upload dir
 		$dir = get_site_option( 'document_upload_directory' );
 		if ( ! ( $dir ) ) {
+			if ( empty( self::$wp_default_dir ) ) {
+				// Set the default upload directory cache
+				$this->set_default_dir_cache();
+			}
 			self::$wpdr_document_dir = self::$wp_default_dir['basedir'];
 			return self::$wpdr_document_dir;
 		}


### PR DESCRIPTION
This change allows the document shortcode to have an additional edit option.

By default this is only allowed for administrators, but a filter is provided to modify it.
The user does then needs the edit_document capability for each individual document for this to be displayed.

This mirrors the capability to have an edit page option on a page but to see the page ordinarily and not to navigate via the Pages admin option.

It also permits the user to display the document directly as before.  
