### PR TITLE
Bump version to V3.2 and Tested WP 4.9.8

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 3.2
+
+* NEW: Add Edit option to Shortcode output (#133, props @NeilWJames)
+* NEW: Support Featured Image (#131, props @NeilWJames)
+
 ### 3.1.2
 
 Fix for 404 error when serving documents from non-standard upload directory.

--- a/docs/header.md
+++ b/docs/header.md
@@ -3,5 +3,5 @@
 Contributors: benbalter
 Tags: documents, uploads, attachments, document management, enterprise, version control, revisions, collaboration, journalism, government, files, revision log, document management, intranet, digital asset management
 Requires at least: 3.9
-Tested up to: 4.9.2
+Tested up to: 4.9.8
 Stable tag: 3.2

--- a/docs/header.md
+++ b/docs/header.md
@@ -4,4 +4,4 @@ Contributors: benbalter
 Tags: documents, uploads, attachments, document management, enterprise, version control, revisions, collaboration, journalism, government, files, revision log, document management, intranet, digital asset management
 Requires at least: 3.9
 Tested up to: 4.9.2
-Stable tag: 3.1.2
+Stable tag: 3.2

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: benbalter
 Tags: documents, uploads, attachments, document management, enterprise, version control, revisions, collaboration, journalism, government, files, revision log, document management, intranet, digital asset management
 Requires at least: 3.9
-Tested up to: 4.9.2
+Tested up to: 4.9.8
 Stable tag: 3.2
 
 == Description ==

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
-=== WP Document Revisions ===
+﻿=== WP Document Revisions ===
 
 Contributors: benbalter
 Tags: documents, uploads, attachments, document management, enterprise, version control, revisions, collaboration, journalism, government, files, revision log, document management, intranet, digital asset management
 Requires at least: 3.9
 Tested up to: 4.9.2
-Stable tag: 3.1.2
+Stable tag: 3.2
 
 == Description ==
 
@@ -101,6 +101,11 @@ See [the full documentation](http://ben.balter.com/wp-document-revisions)
 
 
 == Changelog ==
+
+= 3.2 =
+
+* NEW: Add Edit option to Shortcode output (#133, props @NeilWJames)
+* NEW: Support Featured Image (#131, props @NeilWJames)
 
 = 3.1.2 =
 


### PR DESCRIPTION
Featured Image support bumped the version to 3.2 but some documentation references were not updated.
The WP tested versions has been updated to 4.9.8
Documentation change only