### PR TITLE
Fix for $wp_query->query_vars being null

### DIFF
--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1392,7 +1392,7 @@ class WP_Document_Revisions {
 			}
 
 			// Assume that a document feed is a document feed, even without a post object.
-			if ( ( array_key_exists( 'post_type', $wp_query->query_vars ) ) &&
+			if ( is_array( $wp_query->query_vars ) && ( array_key_exists( 'post_type', $wp_query->query_vars ) ) &&
 			'document' === $wp_query->query_vars['post_type'] && is_feed() ) {
 				return true;
 			}


### PR DESCRIPTION
Fixes https://github.com/benbalter/wp-document-revisions/issues/135.