### PR TITLE
fix multi-network

### DIFF
--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1158,7 +1158,7 @@ class WP_Document_Revisions {
 
 		// make site specific on multisite
 		if ( is_multisite() && ! is_network_admin() ) {
-			if ( is_main_site() ) {
+			if ( is_main_site() && get_current_network_id() === get_main_network_id() ) {
 				$dir = str_replace( '/sites/%site_id%', '', $dir );
 			}
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: benbalter
 Tags: documents, uploads, attachments, document management, enterprise, version control, revisions, collaboration, journalism, government, files, revision log, document management, intranet, digital asset management
-Requires at least: 3.9
+Requires at least: 4.6
 Tested up to: 4.9.8
 Stable tag: 3.2.1
 


### PR DESCRIPTION
- `/sites/%site_id%` should drop if only on the main site of the main network.
- `get_current_network_id()` & `get_main_network_id()` need WordPress 4.6