### PR TITLE
Add the default capabilities only when they are absent.

### DIFF
--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -1466,18 +1466,18 @@ class WP_Document_Revisions_Admin {
 			$attach = get_post( $document->post_content );
 			if ( isset( $attach->ID ) && 'attachment' === $attach->post_type ) {
 
-				// make sure that the attachment is not refered to by another post
+				// make sure that the attachment is not refered to by another post (ignore autosave)
 				global $wpdb;
 				$doc_link = $wpdb->get_var(
 					$wpdb->prepare(
-						"SELECT COUNT(1) FROM $wpdb->posts WHERE %d IN (post_parent, id) AND post_content = %d AND post_name NOT LIKE '%d-autosave-v1' ",
+						"SELECT COUNT(1) FROM $wpdb->posts WHERE %d IN (post_parent, id) AND post_content = %d AND post_name != %s ",
 						$document->post_parent,
 						$document->post_content,
-						$document->post_parent
+						strval( $document->post_parent ) . '-autosave-v1'
 					)
 				);
 
-				if ( 1 == $doc_link ) {
+				if ( '1' === $doc_link ) {
 					$file = get_attached_file( $document->post_content );
 					wp_delete_attachment( $document->post_content, false );
 

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1640,7 +1640,7 @@ class WP_Document_Revisions {
 	 */
 	public function add_caps() {
 		global $wp_roles;
-		if ( ! isset( $wp_roles ) ) {
+		if ( ! is_object( $wp_roles ) ) {
 			// @codingStandardsIgnoreLine
 			$wp_roles = new WP_Roles;
 		}
@@ -1734,11 +1734,22 @@ class WP_Document_Revisions {
 
 			// if the role is a standard role, map the default caps, otherwise, map as a subscriber
 			$caps = ( array_key_exists( $role, $defaults ) ) ? $defaults[ $role ] : $defaults['subscriber'];
+
+			/**
+			 * Filter the default capabilities.
+			 *
+			 * @param array  $caps the default set of capabilities for the role
+			 * @param String $role the role being reviewed (all will be reviewed in turn)
+			 */
 			$caps = apply_filters( 'document_caps', $caps, $role );
 
-			// loop and assign
+			$role_caps = $wp_roles->roles[$role]['capabilities'];
+			// loop through capacities for role
 			foreach ( $caps as $cap => $grant ) {
-				$wp_roles->add_cap( $role, $cap, $grant );
+				// add only missing capabilities
+				if ( ! array_key_exists( $cap, $role_caps ) ) {
+					$wp_roles->add_cap( $role, $cap, $grant );
+				}
 			}
 		}
 

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1743,7 +1743,7 @@ class WP_Document_Revisions {
 			 */
 			$caps = apply_filters( 'document_caps', $caps, $role );
 
-			$role_caps = $wp_roles->roles[$role]['capabilities'];
+			$role_caps = $wp_roles->roles[ $role ]['capabilities'];
 			// loop through capacities for role
 			foreach ( $caps as $cap => $grant ) {
 				// add only missing capabilities


### PR DESCRIPTION
Currently when the plug-in is inactivated and then reactivated, the capabilities revert to the supplied set so, if changed, would need manually resetting to their desired settings.  

By only adding them if they are not present for each role, they will retain their existing values.