### PR TITLE
PHPCS review

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
       "wp-coding-standards/wpcs": "~2.1.1",
       "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
       "php-coveralls/php-coveralls": "*",
-      "squizlabs/php_codesniffer": "*"
+      "squizlabs/php_codesniffer": "~3.4"
     },
     "config": {
      "bin-dir": "bin",

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
 
     },
     "require-dev": {
-      "phpunit/phpunit": "~8.2",
-      "wp-cli/wp-cli": "~2.2",
+      "phpunit/phpunit": "~8.3",
+      "wp-cli/wp-cli": "~2.3",
       "wp-coding-standards/wpcs": "~2.1.1",
       "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
       "php-coveralls/php-coveralls": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8241c6d779e4373154310c9b546ac79d",
+    "content-hash": "4cbfed15c42242b24fa2096d7ab852f2",
     "packages": [],
     "packages-dev": [
         {
@@ -47,9 +47,9 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "role": "Developer / IT Manager",
                     "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl"
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -448,18 +448,18 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "role": "Developer",
-                    "email": "sebastian@phpeople.de"
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "Developer",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
@@ -495,18 +495,18 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "role": "Developer",
-                    "email": "sebastian@phpeople.de"
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "Developer",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
             "description": "Library for handling version information and constraints",
@@ -564,9 +564,9 @@
             "authors": [
                 {
                     "name": "Kitamura Satoshi",
-                    "role": "Original creator",
                     "email": "with.no.parachute@gmail.com",
-                    "homepage": "https://www.facebook.com/satooshi.jp"
+                    "homepage": "https://www.facebook.com/satooshi.jp",
+                    "role": "Original creator"
                 },
                 {
                     "name": "Takashi Matsuo",
@@ -911,8 +911,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "FilterIterator implementation that filters files based on a list of suffixes.",
@@ -953,8 +953,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Simple template engine.",
@@ -1002,8 +1002,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Utility class for timing",
@@ -1944,8 +1944,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
@@ -1987,8 +1987,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
@@ -2048,16 +2048,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v4.3.2",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "9198eea354be75794a7b1064de00d9ae9ae5090f"
+                "reference": "07d49c0f823e0bc367c6d84e35b61419188a5ece"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/9198eea354be75794a7b1064de00d9ae9ae5090f",
-                "reference": "9198eea354be75794a7b1064de00d9ae9ae5090f",
+                "url": "https://api.github.com/repos/symfony/config/zipball/07d49c0f823e0bc367c6d84e35b61419188a5ece",
+                "reference": "07d49c0f823e0bc367c6d84e35b61419188a5ece",
                 "shasum": ""
             },
             "require": {
@@ -2108,20 +2108,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-08T06:33:08+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.3.2",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "b592b26a24265a35172d8a2094d8b10f22b7cc39"
+                "reference": "de63799239b3881b8a08f8481b22348f77ed7b36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/b592b26a24265a35172d8a2094d8b10f22b7cc39",
-                "reference": "b592b26a24265a35172d8a2094d8b10f22b7cc39",
+                "url": "https://api.github.com/repos/symfony/console/zipball/de63799239b3881b8a08f8481b22348f77ed7b36",
+                "reference": "de63799239b3881b8a08f8481b22348f77ed7b36",
                 "shasum": ""
             },
             "require": {
@@ -2183,20 +2183,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-13T11:03:18+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.3.2",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b9896d034463ad6fd2bf17e2bf9418caecd6313d"
+                "reference": "9abbb7ef96a51f4d7e69627bc6f63307994e4263"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b9896d034463ad6fd2bf17e2bf9418caecd6313d",
-                "reference": "b9896d034463ad6fd2bf17e2bf9418caecd6313d",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/9abbb7ef96a51f4d7e69627bc6f63307994e4263",
+                "reference": "9abbb7ef96a51f4d7e69627bc6f63307994e4263",
                 "shasum": ""
             },
             "require": {
@@ -2233,20 +2233,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-23T08:51:25+00:00"
+            "time": "2019-08-20T14:07:54+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.3.2",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "33c21f7d5d3dc8a140c282854a7e13aeb5d0f91a"
+                "reference": "86c1c929f0a4b24812e1eb109262fc3372c8e9f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/33c21f7d5d3dc8a140c282854a7e13aeb5d0f91a",
-                "reference": "33c21f7d5d3dc8a140c282854a7e13aeb5d0f91a",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/86c1c929f0a4b24812e1eb109262fc3372c8e9f2",
+                "reference": "86c1c929f0a4b24812e1eb109262fc3372c8e9f2",
                 "shasum": ""
             },
             "require": {
@@ -2282,7 +2282,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-13T11:03:18+00:00"
+            "time": "2019-08-14T12:26:46+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2344,16 +2344,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.11.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
-                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/b42a2f66e8f1b15ccf25652c3424265923eb4f17",
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17",
                 "shasum": ""
             },
             "require": {
@@ -2365,7 +2365,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -2399,20 +2399,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.11.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "d1fb4abcc0c47be136208ad9d68bf59f1ee17abd"
+                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/d1fb4abcc0c47be136208ad9d68bf59f1ee17abd",
-                "reference": "d1fb4abcc0c47be136208ad9d68bf59f1ee17abd",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/2ceb49eaccb9352bff54d22570276bb75ba4a188",
+                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188",
                 "shasum": ""
             },
             "require": {
@@ -2421,7 +2421,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -2457,20 +2457,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v1.1.5",
+            "version": "v1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f391a00de78ec7ec8cf5cdcdae59ec7b883edb8d"
+                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f391a00de78ec7ec8cf5cdcdae59ec7b883edb8d",
-                "reference": "f391a00de78ec7ec8cf5cdcdae59ec7b883edb8d",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
+                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
                 "shasum": ""
             },
             "require": {
@@ -2515,20 +2515,20 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-06-13T11:15:36+00:00"
+            "time": "2019-08-20T14:44:19+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v4.3.2",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "6b100e9309e8979cf1978ac1778eb155c1f7d93b"
+                "reference": "1e4ff456bd625be5032fac9be4294e60442e9b71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/6b100e9309e8979cf1978ac1778eb155c1f7d93b",
-                "reference": "6b100e9309e8979cf1978ac1778eb155c1f7d93b",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/1e4ff456bd625be5032fac9be4294e60442e9b71",
+                "reference": "1e4ff456bd625be5032fac9be4294e60442e9b71",
                 "shasum": ""
             },
             "require": {
@@ -2565,20 +2565,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-27T08:16:38+00:00"
+            "time": "2019-08-07T11:52:19+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.3.2",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "c60ecf5ba842324433b46f58dc7afc4487dbab99"
+                "reference": "5a0b7c32dc3ec56fd4abae8a4a71b0cf05013686"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/c60ecf5ba842324433b46f58dc7afc4487dbab99",
-                "reference": "c60ecf5ba842324433b46f58dc7afc4487dbab99",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/5a0b7c32dc3ec56fd4abae8a4a71b0cf05013686",
+                "reference": "5a0b7c32dc3ec56fd4abae8a4a71b0cf05013686",
                 "shasum": ""
             },
             "require": {
@@ -2624,7 +2624,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-06T14:04:46+00:00"
+            "time": "2019-08-20T14:27:59+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2668,16 +2668,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
                 "shasum": ""
             },
             "require": {
@@ -2685,8 +2685,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
             "extra": {
@@ -2715,7 +2714,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "time": "2019-08-24T08:43:50+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -2798,13 +2797,13 @@
             "authors": [
                 {
                     "name": "James Logsdon",
-                    "role": "Developer",
-                    "email": "jlogsdon@php.net"
+                    "email": "jlogsdon@php.net",
+                    "role": "Developer"
                 },
                 {
                     "name": "Daniel Bachhuber",
-                    "role": "Maintainer",
-                    "email": "daniel@handbuilt.co"
+                    "email": "daniel@handbuilt.co",
+                    "role": "Maintainer"
                 }
             ],
             "description": "Console utilities for PHP",
@@ -2817,16 +2816,16 @@
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "v2.2.0",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "193f08f48585326bc1f1648349201531eeda2ee5"
+                "reference": "538d9be5ad490bd07b946dcd3b52b4d1c34dc193"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/193f08f48585326bc1f1648349201531eeda2ee5",
-                "reference": "193f08f48585326bc1f1648349201531eeda2ee5",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/538d9be5ad490bd07b946dcd3b52b4d1c34dc193",
+                "reference": "538d9be5ad490bd07b946dcd3b52b4d1c34dc193",
                 "shasum": ""
             },
             "require": {
@@ -2857,7 +2856,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "2.3.x-dev"
                 }
             },
             "autoload": {
@@ -2875,7 +2874,7 @@
                 "cli",
                 "wordpress"
             ],
-            "time": "2019-04-25T05:38:33+00:00"
+            "time": "2019-08-13T23:12:27+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4cbfed15c42242b24fa2096d7ab852f2",
+    "content-hash": "5765b3acc2b260d8f43c4cee0d9b8d2c",
     "packages": [],
     "packages-dev": [
         {

--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -375,16 +375,20 @@ class WP_Document_Revisions_Admin {
 			</a>
 		</div>
 		<p>
-		<strong><?php esc_html_e( 'Latest Version of the Document', 'wp-document-revisions' ); ?>:</strong>
-		<strong><a href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>" target="_BLANK"><?php esc_html_e( 'Download', 'wp-document-revisions' ); ?></a></strong><br />
-		<em>
-		<?php
-		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-		// translators: %1$s is the post date in words, %2$s is the post date in time format, %3$s is how long ago the post was modified, %4$s is the author's name
-		printf( __( 'Checked in <abbr class="timestamp" title="%1$s" id="%2$s">%3$s</abbr> ago by %4$s', 'wp-document-revisions' ), $latest_version->post_date, strtotime( $latest_version->post_date ), human_time_diff( (int) get_post_modified_time( 'U', null, $post->ID ), current_time( 'timestamp' ) ), get_the_author_meta( 'display_name', $latest_version->post_author ) );
-		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
-		?>
-		</a></em>
+		<?php if ( is_object( $latest_version ) ) { ?>
+			<strong>
+			<?php esc_html_e( 'Latest Version of the Document', 'wp-document-revisions' ); ?>
+			</strong>
+			<strong><a href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>" target="_BLANK"><?php esc_html_e( 'Download', 'wp-document-revisions' ); ?></a></strong><br />
+			<em>
+			<?php
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+			// translators: %1$s is the post date in words, %2$s is the post date in time format, %3$s is how long ago the post was modified, %4$s is the author's name
+			printf( __( 'Checked in <abbr class="timestamp" title="%1$s" id="%2$s">%3$s</abbr> ago by %4$s', 'wp-document-revisions' ), $latest_version->post_date, strtotime( $latest_version->post_date ), human_time_diff( (int) get_post_modified_time( 'U', null, $post->ID ), current_time( 'timestamp' ) ), get_the_author_meta( 'display_name', $latest_version->post_author ) );
+			// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
+			?>
+			</a></em>
+		<?php } ?>
 		</p>
 		<div class="clear"></div>
 		<?php

--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -369,16 +369,16 @@ class WP_Document_Revisions_Admin {
 			</div>
 		<?php } ?>
 		<div id="lock_override">
-		<?php $latest_version = $this->get_latest_revision( $post->ID ); ?>
 			<a href="media-upload.php?post_id=<?php echo intval( $post->ID ); ?>&TB_iframe=1" id="content-add_media" class="thickbox add_media button" title="<?php esc_attr_e( 'Upload Document', 'wp-document-revisions' ); ?>" onclick="return false;" >
 				<?php esc_html_e( 'Upload New Version', 'wp-document-revisions' ); ?>
 			</a>
 		</div>
-		<p>
-		<?php if ( is_object( $latest_version ) ) { ?>
-			<strong>
-			<?php esc_html_e( 'Latest Version of the Document', 'wp-document-revisions' ); ?>
-			</strong>
+		<?php
+		$latest_version = $this->get_latest_revision( $post->ID );
+		if ( is_object( $latest_version ) ) {
+			?>
+			<p>
+			<strong><?php esc_html_e( 'Latest Version of the Document', 'wp-document-revisions' ); ?></strong>
 			<strong><a href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>" target="_BLANK"><?php esc_html_e( 'Download', 'wp-document-revisions' ); ?></a></strong><br />
 			<em>
 			<?php
@@ -388,8 +388,8 @@ class WP_Document_Revisions_Admin {
 			// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
 			</a></em>
+			</p>
 		<?php } ?>
-		</p>
 		<div class="clear"></div>
 		<?php
 	}

--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -140,22 +140,23 @@ class WP_Document_Revisions_Admin {
 
 		$messages['document'] = array(
 			// translators: %s is the download link
-				1 => sprintf( __( 'Document updated. <a href="%s">Download document</a>', 'wp-document-revisions' ), esc_url( get_permalink( $post_id ) ) ),
-			2 => __( 'Custom field updated.', 'wp-document-revisions' ),
-			3 => __( 'Custom field deleted.', 'wp-document-revisions' ),
-			4 => __( 'Document updated.', 'wp-document-revisions' ),
+			1  => sprintf( __( 'Document updated. <a href="%s">Download document</a>', 'wp-document-revisions' ), esc_url( get_permalink( $post_id ) ) ),
+			2  => __( 'Custom field updated.', 'wp-document-revisions' ),
+			3  => __( 'Custom field deleted.', 'wp-document-revisions' ),
+			4  => __( 'Document updated.', 'wp-document-revisions' ),
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended
 			// translators: %s is the revision ID
-			// @codingStandardsIgnoreLine WordPress.Security.NonceVerification.NoNonceVerification
-				5 => isset( $_GET['revision'] ) ? sprintf( __( 'Document restored to revision from %s', 'wp-document-revisions' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			5  => isset( $_GET['revision'] ) ? sprintf( __( 'Document restored to revision from %s', 'wp-document-revisions' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			// phpcs:enable WordPress.Security.NonceVerification.Recommended
 			// translators: %s is the download link
-				6 => sprintf( __( 'Document published. <a href="%s">Download document</a>', 'wp-document-revisions' ), esc_url( get_permalink( $post_id ) ) ),
-			7 => __( 'Document saved.', 'wp-document-revisions' ),
+			6  => sprintf( __( 'Document published. <a href="%s">Download document</a>', 'wp-document-revisions' ), esc_url( get_permalink( $post_id ) ) ),
+			7  => __( 'Document saved.', 'wp-document-revisions' ),
 			// translators: %s is the download link
-				8 => sprintf( __( 'Document submitted. <a target="_blank" href="%s">Download document</a>', 'wp-document-revisions' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_id ) ) ) ),
+			8  => sprintf( __( 'Document submitted. <a target="_blank" href="%s">Download document</a>', 'wp-document-revisions' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_id ) ) ) ),
 			// translators: %1$s is the date, %2$s is the preview link
-				9 => sprintf( __( 'Document scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview document</a>', 'wp-document-revisions' ), date_i18n( sprintf( _x( '%1$s @ %2$s', '%1$s: date; %2$s: time', 'wp-document-revision' ), get_option( 'date_format' ), get_option( 'time_format' ) ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post_id ) ) ),
+			9  => sprintf( __( 'Document scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview document</a>', 'wp-document-revisions' ), date_i18n( sprintf( _x( '%1$s @ %2$s', '%1$s: date; %2$s: time', 'wp-document-revision' ), get_option( 'date_format' ), get_option( 'time_format' ) ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post_id ) ) ),
 			// translators: %s is the link to download the document
-				10 => sprintf( __( 'Document draft updated. <a target="_blank" href="%s">Download document</a>', 'wp-document-revisions' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_id ) ) ) ),
+			10 => sprintf( __( 'Document draft updated. <a target="_blank" href="%s">Download document</a>', 'wp-document-revisions' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_id ) ) ) ),
 		);
 
 		return $messages;
@@ -204,7 +205,7 @@ class WP_Document_Revisions_Admin {
 		// child key is the title of the tab
 		// value is the help text (as HTML)
 		$help = array(
-			'document' => array(
+			'document'      => array(
 				__( 'Basic Usage', 'wp-document-revisions' ) =>
 				'<p>' . __( 'This screen allows users to collaboratively edit documents and track their revision history. To begin, enter a title for the document, click <code>Upload New Version</code> and select the file from your computer.', 'wp-document-revisions' ) . '</p><p>' .
 				__( 'Once successfully uploaded, you can enter a revision log message, assign the document an author, and describe its current workflow state.', 'wp-document-revisions' ) . '</p><p>' .
@@ -333,7 +334,7 @@ class WP_Document_Revisions_Admin {
 
 		global $pagenow;
 
-		// @codingStandardsIgnoreLine WordPress.Security.NonceVerification.NoNonceVerification
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( 'media-upload.php' === $pagenow && $this->verify_post_type( $_GET['post_id'] ) ) { ?>
 			<style>
 				#media-upload-header {display:none;}
@@ -361,7 +362,7 @@ class WP_Document_Revisions_Admin {
 			// translators: %s is the user that holds the document lock
 			printf( esc_html__( '%s has prevented other users from making changes.', 'wp-document-revisions' ), esc_html( $lock_holder ) );
 			if ( current_user_can( 'override_document_lock' ) ) {
-				// @codingStandardsIgnoreLine WordPress.XSS.EscapeOutput.OutputNotEscaped
+				// phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction
 				_e( '<br />If you believe this is in error you can <a href="#" id="override_link">override the lock</a>, but their changes will be lost.', 'wp-document-revisions' );
 			}
 			?>
@@ -373,18 +374,18 @@ class WP_Document_Revisions_Admin {
 				<?php esc_html_e( 'Upload New Version', 'wp-document-revisions' ); ?>
 			</a>
 		</div>
-		<?php
-		// @codingStandardsIgnoreStart WordPress.XSS.EscapeOutput.OutputNotEscaped
-		if ( $latest_version = $this->get_latest_revision( $post->ID ) ) { ?>
 		<p>
-			<strong><?php esc_html_e( 'Latest Version of the Document', 'wp-document-revisions' ); ?>:</strong>
-			<strong><a href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>" target="_BLANK"><?php esc_html_e( 'Download', 'wp-document-revisions' ); ?></a></strong><br />
-			<em><?php printf( __( 'Checked in <abbr class="timestamp" title="%1$s" id="%2$s">%3$s</abbr> ago by %4$s', 'wp-document-revisions' ), $latest_version->post_date, strtotime( $latest_version->post_date ), human_time_diff( (int) get_post_modified_time( 'U', null, $post->ID ), current_time( 'timestamp' ) ), get_the_author_meta( 'display_name', $latest_version->post_author ) ) ?></a></em>
-		</p>
+		<strong><?php esc_html_e( 'Latest Version of the Document', 'wp-document-revisions' ); ?>:</strong>
+		<strong><a href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>" target="_BLANK"><?php esc_html_e( 'Download', 'wp-document-revisions' ); ?></a></strong><br />
+		<em>
 		<?php
-			} //end if latest version
-			// @codingStandardsIgnoreEnd WordPress.XSS.EscapeOutput.OutputNotEscaped
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+		// translators: %1$s is the post date in words, %2$s is the post date in time format, %3$s is how long ago the post was modified, %4$s is the author's name
+		printf( __( 'Checked in <abbr class="timestamp" title="%1$s" id="%2$s">%3$s</abbr> ago by %4$s', 'wp-document-revisions' ), $latest_version->post_date, strtotime( $latest_version->post_date ), human_time_diff( (int) get_post_modified_time( 'U', null, $post->ID ), current_time( 'timestamp' ) ), get_the_author_meta( 'display_name', $latest_version->post_author ) );
+		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 		?>
+		</a></em>
+		</p>
 		<div class="clear"></div>
 		<?php
 	}
@@ -412,9 +413,9 @@ class WP_Document_Revisions_Admin {
 	 */
 	public function revision_metabox( $post ) {
 
-		$can_edit_post = current_user_can( 'edit_document', $post->ID );
-		$revisions = $this->get_revisions( $post->ID );
-		$key = $this->get_feed_key();
+		$can_edit_doc = current_user_can( 'edit_document', $post->ID );
+		$revisions    = $this->get_revisions( $post->ID );
+		$key          = $this->get_feed_key();
 		?>
 		<table id="document-revisions">
 			<tr class="header">
@@ -422,7 +423,7 @@ class WP_Document_Revisions_Admin {
 				<th><?php esc_html_e( 'User', 'wp-document-revisions' ); ?></th>
 				<th style="width:50%"><?php esc_html_e( 'Summary', 'wp-document-revisions' ); ?></th>
 				<?php
-				if ( $can_edit_post ) {
+				if ( $can_edit_doc ) {
 					?>
 <th><?php esc_html_e( 'Actions', 'wp-document-revisions' ); ?></th><?php } ?>
 			</tr>
@@ -436,10 +437,10 @@ class WP_Document_Revisions_Admin {
 			// preserve original file extension on revision links.
 			// this will prevent mime/ext security conflicts in IE when downloading.
 			if ( is_numeric( $revision->post_content ) ) {
-				$fn = get_post_meta( $revision->post_content, '_wp_attached_file', true );
-				$fno = pathinfo( $fn, PATHINFO_EXTENSION );
+				$fn   = get_post_meta( $revision->post_content, '_wp_attached_file', true );
+				$fno  = pathinfo( $fn, PATHINFO_EXTENSION );
 				$info = pathinfo( get_permalink( $revision->ID ) );
-				$fn = $info['dirname'] . '/' . $info['filename'] . '.' . $fno;
+				$fn   = $info['dirname'] . '/' . $info['filename'] . '.' . $fno;
 			} else {
 				$fn = get_permalink( $revision->ID );
 			}
@@ -448,7 +449,7 @@ class WP_Document_Revisions_Admin {
 				<td><a href="<?php echo esc_url( $fn ); ?>" title="<?php echo esc_attr( $revision->post_date ); ?>" class="timestamp" id="<?php echo esc_attr( strtotime( $revision->post_date ) ); ?>"><?php echo esc_html( human_time_diff( strtotime( $revision->post_date ), current_time( 'timestamp' ) ) ); ?></a></td>
 				<td><?php echo esc_html( get_the_author_meta( 'display_name', $revision->post_author ) ); ?></td>
 				<td><?php echo esc_html( $revision->post_excerpt ); ?></td>
-				<?php if ( $can_edit_post && $post->ID !== $revision->ID ) { ?>
+				<?php if ( $can_edit_doc && $post->ID !== $revision->ID ) { ?>
 					<td><a href="
 					<?php
 					echo esc_url(
@@ -456,7 +457,7 @@ class WP_Document_Revisions_Admin {
 							add_query_arg(
 								array(
 									'revision' => $revision->ID,
-									'action' => 'restore',
+									'action'   => 'restore',
 								),
 								'revision.php'
 							),
@@ -698,15 +699,17 @@ class WP_Document_Revisions_Admin {
 		<input name="document_upload_directory" type="text" id="document_upload_directory" value="<?php echo esc_attr( $this->document_upload_dir() ); ?>" class="large-text code" /><br />
 		<span class="description">
 		<?php
-			// @codingStandardsIgnoreLine WordPress.XSS.EscapeOutput.OutputNotEscaped
-			_e( 'Directory in which to store uploaded documents. The default is in your <code>wp_content/uploads</code> folder (or another default uploads folder defined elsewhere), but it may be moved to a folder outside of the <code>htdocs</code> or <code>public_html</code> folder for added security.', 'wp-document-revisions' ); ?></span>
+		// phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction
+		_e( 'Directory in which to store uploaded documents. The default is in your <code>wp_content/uploads</code> folder (or another default uploads folder defined elsewhere), but it may be moved to a folder outside of the <code>htdocs</code> or <code>public_html</code> folder for added security.', 'wp-document-revisions' );
+		?>
+		</span>
 		<?php if ( is_multisite() ) : ?>
 		<span class="description">
 			<?php
-			// @codingStandardsIgnoreStart WordPress.XSS.EscapeOutput.OutputNotEscaped
+			// phpcs:disable WordPress.Security.EscapeOutput.UnsafePrintingFunction
 			// translators: %site_id% is not interpolated and should not be translated
 			_e( 'You may optionally include the string <code>%site_id%</code> within the path to separate files by site.', 'wp-document-revisions' );
-			// @codingStandardsIgnoreEnd WordPress.XSS.EscapeOutput.OutputNotEscaped
+			// phpcs:enable WordPress.Security.EscapeOutput.UnsafePrintingFunction
 			?>
 		</span>
 			<?php
@@ -722,8 +725,10 @@ class WP_Document_Revisions_Admin {
 	<code><?php bloginfo( 'url' ); ?>/<input name="document_slug" type="text" id="document_slug" value="<?php echo esc_attr( $this->document_slug() ); ?>" class="medium-text" />/<?php echo esc_html( date( 'Y' ) ); ?>/<?php echo esc_html( date( 'm' ) ); ?>/<?php esc_html_e( 'example-document-title', 'wp-document-revisions' ); ?>.txt</code><br />
 	<span class="description">
 		<?php
-		// @codingStandardsIgnoreLine WordPress.XSS.EscapeOutput.OutputNotEscaped
-		_e( '"Slug" with which to prefix all URLs for documents (and the document archive). Default is <code>documents</code>.', 'wp-document-revisions' ); ?></span>
+		// phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction
+		_e( '"Slug" with which to prefix all URLs for documents (and the document archive). Default is <code>documents</code>.', 'wp-document-revisions' );
+		?>
+	</span>
 		<?php
 	}
 
@@ -804,7 +809,7 @@ class WP_Document_Revisions_Admin {
 		do_action( 'document_lock_notice', $post );
 
 		// if there is no page var, this is a new document, no need to warn
-		// @codingStandardsIgnoreLine WordPress.Security.NonceVerification.NoNonceVerification
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['post'] ) ) :
 			?>
 		<div class="error" id="lock-notice"><p><?php esc_html_e( 'You currently have this file checked out. No other user can edit this document so long as you remain on this page.', 'wp-document-revisions' ); ?></p></div>
@@ -990,17 +995,17 @@ class WP_Document_Revisions_Admin {
 				$tax_slug = EF_Custom_Status::taxonomy_key;
 			}
 			$args = array(
-				'name' => 'workflow_state',
+				'name'            => 'workflow_state',
 				'show_option_all' => __( 'All workflow states', 'wp-document-revisions' ),
-				'hide_empty' => false,
-				'taxonomy' => $tax_slug,
+				'hide_empty'      => false,
+				'taxonomy'        => $tax_slug,
 			);
 
 			// set selected workflow state
 			if ( isset( $wp_query->query[ $tax_slug ] ) ) {
 				$term_id = $wp_query->query[ $tax_slug ];
 				if ( ! is_numeric( $term_id ) && '0' !== $term_id ) {
-					$term = get_term_by( 'slug', $wp_query->query[ $tax_slug ], $tax_slug );
+					$term    = get_term_by( 'slug', $wp_query->query[ $tax_slug ], $tax_slug );
 					$term_id = $term->term_id;
 				}
 				$args['selected'] = $term_id;
@@ -1013,14 +1018,14 @@ class WP_Document_Revisions_Admin {
 
 			// author/owner filtering
 			$args = array(
-				'name' => 'author',
+				'name'            => 'author',
 				'show_option_all' => __( 'All owners', 'wp-document-revisions' ),
 			);
-		// @codingStandardsIgnoreStart WordPress.Security.NonceVerification.NoNonceVerification
-		if ( isset( $_GET['author'] ) ) {
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended
+			if ( isset( $_GET['author'] ) ) {
 				$args['selected'] = $_GET['author'];
 			}
-		// @codingStandardsIgnoreEnd WordPress.Security.NonceVerification.NoNonceVerification
+			// phpcs:enable WordPress.Security.NonceVerification.Recommended
 			wp_dropdown_users( $args );
 		}
 	}
@@ -1040,7 +1045,7 @@ class WP_Document_Revisions_Admin {
 			$var = &$query->query_vars[ $tax_slug ];
 			if ( isset( $var ) && is_numeric( $var ) && '0' !== $var ) {
 				$term = get_term_by( 'id', $var, $tax_slug );
-				$var = $term->slug;
+				$var  = $term->slug;
 			}
 		}
 	}
@@ -1167,7 +1172,7 @@ class WP_Document_Revisions_Admin {
 			$post->ID,
 			'workflow_state'
 		);
-		$states = get_terms(
+		$states        = get_terms(
 			'workflow_state',
 			array( 'hide_empty' => false )
 		);
@@ -1227,15 +1232,15 @@ class WP_Document_Revisions_Admin {
 		global $wpdb;
 		$thumb = get_post_meta( $doc_id, '_thumbnail_id', true );
 		if ( $thumb > 0 ) {
-			// @codingStandardsIgnoreStart WordPress.DB.PreparedSQL.NotPrepared
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
 			$post_table = "{$wpdb->prefix}posts";
-			$sql = $wpdb->prepare(
+			$sql        = $wpdb->prepare(
 				"UPDATE `$post_table` SET `post_parent` = 0 WHERE `id` = %d AND `post_parent` = %d ",
 				$thumb,
 				$doc_id
 			);
-			$res = $wpdb->query( $sql );
-			// @codingStandardsIgnoreEnd WordPress.DB.PreparedSQL.NotPrepared
+			$res        = $wpdb->query( $sql );
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
 		}
 
 		$old = wp_get_post_terms( $doc_id, 'workflow_state', true );
@@ -1548,7 +1553,7 @@ class WP_Document_Revisions_Admin {
 		 * @param WP_Post link to (new) global post
 		 * @param WP_Post link to clone of global post
 		 */
-		// @codingStandardsIgnoreLine WordPress.Variables.GlobalVariables.OverrideProhibited
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$post = apply_filters( 'document_to_private', $post, $post_pre );
 
 	}
@@ -1594,13 +1599,13 @@ class WP_Document_Revisions_Admin {
 			return;
 		}
 
-		// @codingStandardsIgnoreLine WordPress.XSS.EscapeOutput.OutputNotEscaped
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '<ul>';
 
 		foreach ( $documents as $document ) :
 			$link = ( current_user_can( 'edit_document', $document->ID ) ) ? add_query_arg(
 				array(
-					'post' => $document->ID,
+					'post'   => $document->ID,
 					'action' => 'edit',
 				),
 				admin_url( 'post.php' )
@@ -1622,7 +1627,7 @@ class WP_Document_Revisions_Admin {
 			<?php
 		endforeach;
 
-		// @codingStandardsIgnoreLine WordPress.XSS.EscapeOutput.OutputNotEscaped
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '</ul>';
 	}
 }

--- a/includes/class-wp-document-revisions-front-end.php
+++ b/includes/class-wp-document-revisions-front-end.php
@@ -31,7 +31,7 @@ class WP_Document_Revisions_Front_End {
 	 * @var $shortcode_defaults
 	 */
 	public $shortcode_defaults = array(
-		'id' => null,
+		'id'     => null,
 		'number' => null,
 	);
 
@@ -120,13 +120,17 @@ class WP_Document_Revisions_Front_End {
 		<ul class="revisions document-<?php echo esc_attr( $id ); ?>">
 		<?php
 		// loop through each revision
-		// @codingStandardsIgnoreStart WordPress.XSS.EscapeOutput.OutputNotEscaped
-		foreach ( $revisions as $revision ) { ?>
+		// phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
+		foreach ( $revisions as $revision ) {
+			?>
 			<li class="revision revision-<?php echo esc_attr( $revision->ID ); ?>" >
-				<?php printf( __( '<a href="%1$s" title="%2$s" id="%3$s" class="timestamp">%4$s</a> <span class="agoby">ago by</a> <span class="author">%5$s</a>', 'wp-document-revisions' ), esc_url( get_permalink( $revision->ID ) ), esc_attr( $revision->post_date ), esc_html( strtotime( $revision->post_date ) ), esc_html( human_time_diff( strtotime( $revision->post_date ) ), current_time( 'timestamp' ) ), esc_html( get_the_author_meta( 'display_name', $revision->post_author ) ) ); ?>
+				<?php
+				// html - string not to be translated
+				printf( '<a href="%1$s" title="%2$s" id="%3$s" class="timestamp">%4$s</a> <span class="agoby">ago by</a> <span class="author">%5$s</a>', esc_url( get_permalink( $revision->ID ) ), esc_attr( $revision->post_date ), esc_html( strtotime( $revision->post_date ) ), esc_html( human_time_diff( strtotime( $revision->post_date ) ), current_time( 'timestamp' ) ), esc_html( get_the_author_meta( 'display_name', $revision->post_author ) ) );
+				?>
 			</li>
-		<?php
-		// @codingStandardsIgnoreEnd WordPress.XSS.EscapeOutput.OutputNotEscaped
+			<?php
+		// phpcs:enable WordPress.XSS.EscapeOutput.OutputNotEscaped
 		}
 		?>
 		</ul>
@@ -151,7 +155,7 @@ class WP_Document_Revisions_Front_End {
 
 		$defaults = array(
 			'orderby' => 'modified',
-			'order' => 'DESC',
+			'order'   => 'DESC',
 		);
 
 		// list of all string or int based query vars (because we are going through shortcode)
@@ -232,7 +236,7 @@ class WP_Document_Revisions_Front_End {
 
 		// check whether to show update option. Default - only administrator role
 		$show_edit = false;
-		$user = wp_get_current_user();
+		$user      = wp_get_current_user();
 		if ( $user->ID > 0 ) {
 			// logged on user only
 			$roles = (array) $user->roles;
@@ -268,13 +272,12 @@ class WP_Document_Revisions_Front_End {
 			if ( $show_edit && current_user_can( 'edit_document', $document->ID ) ) {
 				$link = add_query_arg(
 					array(
-						'post' => $document->ID,
+						'post'   => $document->ID,
 						'action' => 'edit',
 					),
 					admin_url( 'post.php' )
 				);
-				// @codingStandardsIgnoreLine WordPress.XSS.EscapeOutput.OutputNotEscaped
-				echo '&nbsp;&nbsp;<a class="document-mod" href="' . esc_attr( $link ) . '">[' . __( 'Edit', 'wp-document-revisions' ) . ']</a>';
+				echo '&nbsp;&nbsp;<a class="document-mod" href="' . esc_attr( $link ) . '">[' . esc_html__( 'Edit', 'wp-document-revisions' ) . ']</a>';
 			}
 			?>
 			</li>

--- a/includes/class-wp-document-revisions-recently-revised-widget.php
+++ b/includes/class-wp-document-revisions-recently-revised-widget.php
@@ -21,7 +21,7 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 		'post_status' => array(
 			'publish' => true,
 			'private' => false,
-			'draft' => false,
+			'draft'   => false,
 		),
 		'show_author' => true,
 	);
@@ -68,13 +68,13 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 			return;
 		}
 
-		// @codingStandardsIgnoreLine WordPress.XSS.EscapeOutput.OutputNotEscaped
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $args['before_widget'] . $args['before_title'] . esc_html( apply_filters( 'widget_title', $instance['title'] ) ) . $args['after_title'] . '<ul>';
 
 		foreach ( $documents as $document ) :
 			$link = ( current_user_can( 'edit_document', $document->ID ) ) ? add_query_arg(
 				array(
-					'post' => $document->ID,
+					'post'   => $document->ID,
 					'action' => 'edit',
 				),
 				admin_url( 'post.php' )
@@ -89,7 +89,7 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 			<?php
 		endforeach;
 
-		// @codingStandardsIgnoreLine WordPress.XSS.EscapeOutput.OutputNotEscaped
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '</ul>' . $args['after_widget'];
 	}
 
@@ -138,7 +138,7 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	 */
 	public function update( $new_instance, $old_instance ) {
 
-		$instance = $old_instance;
+		$instance                = $old_instance;
 		$instance['title']       = wp_strip_all_tags( $new_instance['title'] );
 		$instance['numberposts'] = (int) $new_instance['numberposts'];
 		$instance['show_author'] = (bool) $new_instance['show_author'];

--- a/includes/revision-feed.php
+++ b/includes/revision-feed.php
@@ -13,7 +13,7 @@ if ( ! $wpdr ) {
 
 $rev_query = $wpdr->get_revision_query( $post->ID, true );
 
-// @codingStandardsIgnoreLine WordPress.PHP.NoSilencedErrors.Discouraged
+// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 @header( 'Content-Type: ' . feed_content_type( 'rss-http' ) . '; charset=' . get_option( 'blog_charset' ), true );
 
 echo '<?xml version="1.0" encoding="' . ent2ncr( esc_attr( get_option( 'blog_charset' ) ) ) . '"?' . '>'; ?>

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -5,17 +5,9 @@
 	<rule ref="WordPress-Core">
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
-		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged" />
-		<exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification" />
-		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
-		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning" />
 	</rule>
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />
-
-	<rule ref="Generic.Files.OneObjectStructurePerFile.MultipleFound">
-		<exclude-pattern>includes/class-wp-document-revisions-front-end.php</exclude-pattern>
-	</rule>
 
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/vendor/autoload.php</exclude-pattern>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -67,9 +67,9 @@ require $_tests_dir . '/includes/bootstrap.php';
 function _make_user( $role = 'administrator', $user_login = '', $pass = '', $email = '' ) {
 
 	$user = array(
-		'role' => $role,
+		'role'       => $role,
 		'user_login' => ( $user_login ) ? $user_login : rand_str(),
-		'user_pass' => ( $pass ) ? $pass : rand_str(),
+		'user_pass'  => ( $pass ) ? $pass : rand_str(),
 		'user_email' => ( $email ) ? $email : rand_str() . '@example.com',
 	);
 
@@ -135,7 +135,7 @@ function _rrmdir( $dir ) {
  */
 function _destroy_uploads() {
 	$uploads = wp_upload_dir();
-	$files = array_diff( scandir( $uploads['basedir'] ), array( '..', '.' ) );
+	$files   = array_diff( scandir( $uploads['basedir'] ), array( '..', '.' ) );
 	foreach ( $files as $file ) {
 		_rrmdir( $uploads['basedir'] . '/' . $file );
 	}

--- a/tests/class-test-wp-document-revisions-front-end.php
+++ b/tests/class-test-wp-document-revisions-front-end.php
@@ -47,7 +47,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	 */
 	public function test_revisions_shortcode_unauthed() {
 
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_revise_document();
 
 		$output = do_shortcode( '[document_revisions id="' . $doc_id . '"]' );
@@ -61,7 +61,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	 */
 	public function test_revisions_shortcode() {
 
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_revise_document();
 
 		// admin should be able to access
@@ -79,7 +79,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	 */
 	public function test_revision_shortcode_limit() {
 
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_revise_document();
 
 		// admin should be able to access
@@ -142,7 +142,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	 */
 	public function test_document_shortcode_post_meta_filter() {
 
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_add_document(); // add a doc
 		wp_publish_post( $doc_id );
 
@@ -181,12 +181,12 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	 */
 	public function test_get_documents_returns_attachments() {
 
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_add_document(); // add a doc
 		wp_publish_post( $doc_id );
 
 		$docs = get_documents( null, true );
-		$doc = array_pop( $docs );
+		$doc  = array_pop( $docs );
 
 		$this->assertEquals( $doc->post_type, 'attachment', 'get_documents not returning attachments' );
 
@@ -222,7 +222,7 @@ class Test_WP_Document_Revisions_Front_End extends WP_UnitTestCase {
 	 * Tests the get_revisions function
 	 */
 	public function test_get_document_revisions() {
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_revise_document(); // add a doc
 		$this->assertCount( 2, get_document_revisions( $doc_id ) );
 	}

--- a/tests/class-test-wp-document-revisions-rewrites.php
+++ b/tests/class-test-wp-document-revisions-rewrites.php
@@ -117,7 +117,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 		global $wpdr;
 
 		// make new public document
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_add_document();
 		wp_publish_post( $doc_id );
 
@@ -136,7 +136,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	public function test_private_document_as_unauthenticated() {
 
 		// make new private document
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_add_document();
 
 		global $current_user;
@@ -157,7 +157,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	public function test_private_document_as_contributor() {
 
 		// make new private document
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_add_document();
 
 		// contibutor should be denied
@@ -177,11 +177,11 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	public function test_private_document_as_admin() {
 
 		// make new private document
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_add_document();
 
 		// admin should be able to access
-		$id = _make_user( 'administrator' );
+		$id   = _make_user( 'administrator' );
 		$user = wp_set_current_user( $id );
 
 		$this->verify_download( "?p=$doc_id&post_type=document", $tdr->test_file, 'Private, Admin Ugly Permalink' );
@@ -198,11 +198,11 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 		global $wpdr;
 
 		// make new public, revised document
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_revise_document();
 		wp_publish_post( $doc_id );
 		$revisions = $wpdr->get_revisions( $doc_id );
-		$revision = array_pop( $revisions );
+		$revision  = array_pop( $revisions );
 
 		global $current_user;
 		unset( $current_user );
@@ -224,11 +224,11 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 		global $wpdr;
 
 		// make new public, revised document
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_revise_document();
 		wp_publish_post( $doc_id );
 		$revisions = $wpdr->get_revisions( $doc_id );
-		$revision = array_pop( $revisions );
+		$revision  = array_pop( $revisions );
 
 		// admin should be able to access
 		$id = _make_user( 'administrator' );
@@ -250,7 +250,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 		global $wpdr;
 
 		// make new public, revised document
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_revise_document();
 		wp_publish_post( $doc_id );
 
@@ -265,7 +265,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	 */
 	public function test_archive() {
 		global $wpdr;
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_add_document();
 		flush_rewrite_rules();
 		$this->go_to( get_home_url( null, $wpdr->document_slug() ) );
@@ -279,9 +279,9 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	public function test_permalink() {
 
 		global $wpdr;
-		$tdr = new Test_WP_Document_Revisions();
-		$doc_id = $tdr->test_add_document();
-		$doc = get_post( $doc_id );
+		$tdr       = new Test_WP_Document_Revisions();
+		$doc_id    = $tdr->test_add_document();
+		$doc       = get_post( $doc_id );
 		$permalink = get_bloginfo( 'url' ) . '/' . $wpdr->document_slug() . '/' . date( 'Y' ) . '/' . date( 'm' ) . '/' . $doc->post_name . $wpdr->get_file_type( $doc_id );
 		$this->assertEquals( $permalink, get_permalink( $doc_id ), 'Bad permalink' );
 
@@ -294,10 +294,10 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 	public function test_revision_permalink() {
 
 		global $wpdr;
-		$tdr = new Test_WP_Document_Revisions();
-		$doc_id = $tdr->test_revise_document();
+		$tdr       = new Test_WP_Document_Revisions();
+		$doc_id    = $tdr->test_revise_document();
 		$revisions = $wpdr->get_revisions( $doc_id );
-		$revision = array_pop( $revisions );
+		$revision  = array_pop( $revisions );
 		$permalink = get_bloginfo( 'url' ) . '/' . $wpdr->document_slug() . '/' . date( 'Y' ) . '/' . date( 'm' ) . '/' . get_post( $doc_id )->post_name . '-revision-1' . $wpdr->get_file_type( $doc_id );
 		$this->assertEquals( $permalink, get_permalink( $revision->ID ), 'Bad revision permalink' );
 	}
@@ -346,7 +346,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 
 		global $wpdr;
 
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_add_document();
 
 		// try to get an un auth'd feed
@@ -368,7 +368,7 @@ class Test_WP_Document_Revisions_Rewrites extends WP_UnitTestCase {
 		define( 'WP_ADMIN', true );
 
 		$wpdr->admin_init();
-		$tdr = new Test_WP_Document_Revisions();
+		$tdr    = new Test_WP_Document_Revisions();
 		$doc_id = $tdr->test_add_document();
 
 		// try to get an auth'd feed

--- a/tests/class-test-wp-document-revisions.php
+++ b/tests/class-test-wp-document-revisions.php
@@ -107,26 +107,26 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 	public function spoof_upload( $post_id, $file ) {
 
 		global $wpdr;
-		$file = dirname( __FILE__ ) . '/' . $file;
+		$file             = dirname( __FILE__ ) . '/' . $file;
 		$_POST['post_id'] = $post_id;
-		$upload_dir = wp_upload_dir();
+		$upload_dir       = wp_upload_dir();
 
 		$wp_filetype = wp_check_filetype( basename( $file ), null );
-		$file_array = apply_filters(
+		$file_array  = apply_filters(
 			'wp_handle_upload_prefilter',
 			array(
-				'name' => basename( $file ),
+				'name'     => basename( $file ),
 				'tmp_name' => $file,
-				'type' => $wp_filetype['type'],
-				'size' => 1,
+				'type'     => $wp_filetype['type'],
+				'size'     => 1,
 			)
 		);
 
 		$attachment = array(
 			'post_mime_type' => $wp_filetype['type'],
-			'post_title' => preg_replace( '/\.[^.]+$/', '', basename( $file ) ),
-			'post_content' => '',
-			'post_status' => 'inherit',
+			'post_title'     => preg_replace( '/\.[^.]+$/', '', basename( $file ) ),
+			'post_content'   => '',
+			'post_status'    => 'inherit',
 		);
 
 		// If the directory is not available, the upload does not succeed.
@@ -156,11 +156,11 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 		global $wpdb;
 
 		$doc = array(
-			'post_title' => 'Test Document - ' . time(),
-			'post_status' => 'private',
+			'post_title'   => 'Test Document - ' . time(),
+			'post_status'  => 'private',
 			'post_content' => '',
 			'post_excerpt' => 'Test Upload',
-			'post_type' => 'document',
+			'post_type'    => 'document',
 		);
 
 		// insert post
@@ -218,8 +218,8 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 
 		$attach_id = $this->spoof_upload( $doc_id, $this->test_file2 );
 
-		$doc = array(
-			'ID' => $doc_id,
+		$doc    = array(
+			'ID'           => $doc_id,
 			'post_content' => $attach_id,
 			'post_excerpt' => 'revised',
 		);
@@ -247,7 +247,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 			return;
 		}
 
-		$doc = get_post( $post_id );
+		$doc        = get_post( $post_id );
 		$attachment = get_attached_file( $doc->post_content );
 
 		$this->assertFileEquals( dirname( __FILE__ ) . '/' . $file, $attachment, "Uploaded files don\'t match original ($msg)" );
@@ -266,11 +266,11 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 
 		// grab an attachment
 		$attachments = $wpdr->get_attachments( $doc_id );
-		$attachment = end( $attachments );
+		$attachment  = end( $attachments );
 
 		// grab a revision
 		$revisions = $wpdr->get_revisions( $doc_id );
-		$revision = end( $revisions );
+		$revision  = end( $revisions );
 
 		// get as postID
 		$this->assertCount( 2, $attachments, 'Bad attachment count via get_attachments as postID' );
@@ -298,7 +298,7 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 
 		// grab an attachment
 		$attachments = $wpdr->get_attachments( $doc_id );
-		$attachment = end( $attachments );
+		$attachment  = end( $attachments );
 
 		global $wpdr;
 		$this->assertEquals( '.txt', $wpdr->get_file_type( $doc_id ), 'Didn\'t detect filetype via document ID' );
@@ -327,9 +327,9 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 
 		global $wpdr;
 
-		$doc_id = $this->test_revise_document();
+		$doc_id    = $this->test_revise_document();
 		$revisions = $wpdr->get_revisions( $doc_id );
-		$last = end( $revisions );
+		$last      = end( $revisions );
 		$this->assertEquals( 1, $wpdr->get_revision_number( $last->ID ) );
 		$this->assertEquals( $last->ID, $wpdr->get_revision_id( 1, $doc_id ) );
 
@@ -359,10 +359,10 @@ class Test_WP_Document_Revisions extends WP_UnitTestCase {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		unset( $_REQUEST['post_id'] );
 
-		// @codingStandardsIgnoreStart WordPress.Variables.GlobalVariables.OverrideProhibited
+		// phpcs:disable WordPress.Variables.GlobalVariables.OverrideProhibited
 		global $post;
 		$post = get_post( $doc_id );
-		// @codingStandardsIgnoreEnd WordPress.Variables.GlobalVariables.OverrideProhibited
+		// phpcs:enable WordPress.Variables.GlobalVariables.OverrideProhibited
 
 		$this->assertTrue( $wpdr->verify_post_type( $post ), 'verify post type via global $post' );
 		unset( $post );

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Document Revisions
 Plugin URI: http://ben.balter.com/2011/08/29/wp-document-revisions-document-management-version-control-wordpress/
 Description: A document management and version control plugin for WordPress that allows teams of any size to collaboratively edit files and manage their workflow.
-Version: 3.2.2
+Version: 3.2.3
 Author: Ben Balter
 Author URI: http://ben.balter.com
 License: GPL3
@@ -34,15 +34,12 @@ Domain Path: /languages
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- *  @copyright 2011-2017
+ *  @copyright 2011-2019
  *  @license GPL v3
- *  @version 3.2.2
+ *  @version 3.2.3
  *  @package WP_Document_Revisions
  *  @author Ben Balter <ben@balter.com>
  */
-// @codingStandardsIgnoreStart WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_set_include_path
-set_include_path( get_include_path() . PATH_SEPARATOR . dirname( __FILE__ ) . '/includes' );
-// @codingStandardsIgnoreEnd WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_set_include_path
 require_once dirname( __FILE__ ) . '/includes/class-wp-document-revisions.php';
 
 // $wpdr is a global reference to the class.


### PR DESCRIPTION
phpcs:ignore replaces @codingStandards so comments updated.
Some sniffs have been renamed so code updated in line.
Excludes that can be auto fixed have been (except for line endings as these can vary between PC, Linux and Mac).
