### PR TITLE
On plugin activation, check that the user has edit_documents capability. If not, a warning message will be output that the menu may be incorrect.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ### 3.2.3
 
+* On plugin activation, admin warning if user doesn't have edit_documents capability (#180) @NeilWJames
+* PHPCS Review (no functional changes) (#179) @NeilWJames
 * Review for WP Coding standard 2.1.1 and newer phpunit (#174) @NeilWJames
 * Bump version to V3.2.3 and Tested WP 5.2.2 (#174) @NeilWJames
 

--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -369,16 +369,16 @@ class WP_Document_Revisions_Admin {
 			</div>
 		<?php } ?>
 		<div id="lock_override">
-		<?php $latest_version = $this->get_latest_revision( $post->ID ); ?>
 			<a href="media-upload.php?post_id=<?php echo intval( $post->ID ); ?>&TB_iframe=1" id="content-add_media" class="thickbox add_media button" title="<?php esc_attr_e( 'Upload Document', 'wp-document-revisions' ); ?>" onclick="return false;" >
 				<?php esc_html_e( 'Upload New Version', 'wp-document-revisions' ); ?>
 			</a>
 		</div>
-		<p>
-		<?php if ( is_object( $latest_version ) ) { ?>
-			<strong>
-			<?php esc_html_e( 'Latest Version of the Document', 'wp-document-revisions' ); ?>
-			</strong>
+		<?php
+		$latest_version = $this->get_latest_revision( $post->ID );
+		if ( is_object( $latest_version ) ) {
+			?>
+			<p>
+			<strong><?php esc_html_e( 'Latest Version of the Document', 'wp-document-revisions' ); ?></strong>
 			<strong><a href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>" target="_BLANK"><?php esc_html_e( 'Download', 'wp-document-revisions' ); ?></a></strong><br />
 			<em>
 			<?php
@@ -388,8 +388,8 @@ class WP_Document_Revisions_Admin {
 			// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
 			</a></em>
+			</p>
 		<?php } ?>
-		</p>
 		<div class="clear"></div>
 		<?php
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,8 @@ See [the full documentation](http://ben.balter.com/wp-document-revisions)
 
 = 3.2.3 =
 
+* On plugin activation, admin warning if user doesn't have edit_documents capability (#180) @NeilWJames
+* PHPCS Review (no functional changes) (#179) @NeilWJames
 * Review for WP Coding standard 2.1.1 and newer phpunit (#174) @NeilWJames
 * Bump version to V3.2.3 and Tested WP 5.2.2 (#144) @NeilWJames
 


### PR DESCRIPTION
Reviewing a number of Support requests both recent and old users have complained that the Documents menu item does not appear.

This can occur if the user has a number of roles where one does NOT have edit_documents capability and deny over-rides allow; or is using an custom "administrator" role.

[Full disclosure. I have previously had this issue - and it *is* very confusing]