### PR TITLE
Add filter for: no attachment found response code.

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -85,6 +85,12 @@ In: class-wp-document-revisions.php
 
 Filters the http response code when a document revision (attachment) is not found.
 
+> [!WARNING]  
+> Modifying the response code from the default value of 403 may introduce an existence vulnerability.
+> 
+> By comparing 403 responses (revision found but not authorized) to 404 responses (revision not found)
+> a non-authorized user can determine if a document exists or not.
+
 ## Filter document_output_sent_is_ok
 
 In: class-wp-document-revisions.php

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -79,6 +79,12 @@ In: class-wp-document-revisions.php
 
 Filters the lost lock document email text.
 
+## Filter document_no_revision_found_response_code
+
+In: class-wp-document-revisions.php
+
+Filters the http response code when a document revision (attachment) is not found.
+
 ## Filter document_output_sent_is_ok
 
 In: class-wp-document-revisions.php

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1278,7 +1278,7 @@ class WP_Document_Revisions {
 				wp_die(
 					esc_html__( 'No document file is attached.', 'wp-document-revisions' ),
 					null,
-					array( 'response' => apply_filters( 'document_no_revision_found_response_code', 403 ) )
+					array( 'response' => absint( apply_filters( 'document_no_revision_found_response_code', 403 ) ) )
 				);
 				// for unit testing.
 				$wp_query->is_404 = true;

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1278,7 +1278,7 @@ class WP_Document_Revisions {
 				wp_die(
 					esc_html__( 'No document file is attached.', 'wp-document-revisions' ),
 					null,
-					array( 'response' => 403 )
+					array( 'response' => apply_filters( 'document_no_revision_found_response_code', 403 )
 				);
 				// for unit testing.
 				$wp_query->is_404 = true;

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1278,7 +1278,7 @@ class WP_Document_Revisions {
 				wp_die(
 					esc_html__( 'No document file is attached.', 'wp-document-revisions' ),
 					null,
-					array( 'response' => apply_filters( 'document_no_revision_found_response_code', 403 )
+					array( 'response' => apply_filters( 'document_no_revision_found_response_code', 403 ) )
 				);
 				// for unit testing.
 				$wp_query->is_404 = true;


### PR DESCRIPTION
This PR adds a filter to modify the http response code when a document revision (attachment) is not found.

Justification:

In my installation, we server a genetic error page for 403 response codes. This error page is misleading since it explains that the user is forbidden for accessing the resource. Hence, a 404 is more suitable.

This filter allows for  a 404 to be served, while maintaining backwards compatibility of returning 403 by default.