### PR TITLE
Audit improvements: streaming downloads, single version constant, header hardening

### DIFF
--- a/includes/class-wp-document-revisions-front-end.php
+++ b/includes/class-wp-document-revisions-front-end.php
@@ -162,7 +162,7 @@ class WP_Document_Revisions_Front_End {
 		// buffer output to return rather than echo directly.
 		ob_start();
 		?>
-		<ul class="revisions document-<?php echo esc_attr( $id ); ?>">
+		<ul class="revisions document-<?php echo esc_attr( (string) $id ); ?>">
 		<?php
 		// loop through each revision.
 		foreach ( $revisions as $revision ) {

--- a/includes/class-wp-document-revisions-front-end.php
+++ b/includes/class-wp-document-revisions-front-end.php
@@ -113,9 +113,10 @@ class WP_Document_Revisions_Front_End {
 
 		// normalize args.
 		$atts = shortcode_atts( $this->shortcode_defaults, $atts, 'document' );
-		foreach ( array_keys( (array) $this->shortcode_defaults ) as $key ) {
-			$$key = isset( $atts[ $key ] ) ? (int) $atts[ $key ] : null;
-		}
+		// Extract recognized shortcode attributes into explicit local variables
+		// (avoids the dynamic `$$key` pattern, which is opaque to static analysis).
+		$id          = isset( $atts['id'] ) ? (int) $atts['id'] : null;
+		$numberposts = isset( $atts['numberposts'] ) ? (int) $atts['numberposts'] : null;
 
 		// do not show output to users that do not have the read_document_revisions capability.
 		if ( ! current_user_can( 'read_document_revisions' ) ) {

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -39,9 +39,12 @@ class WP_Document_Revisions {
 	/**
 	 * The plugin version.
 	 *
+	 * Sourced from the WPDR_VERSION constant defined in the main plugin file
+	 * so the version string lives in exactly one place.
+	 *
 	 * @var string
 	 */
-	public $version = '4.0.4';
+	public $version = WPDR_VERSION;
 
 	/**
 	 * The WP default upload directory cache.

--- a/includes/trait-wp-document-revisions-file-handler.php
+++ b/includes/trait-wp-document-revisions-file-handler.php
@@ -177,6 +177,11 @@ trait WP_Document_Revisions_File_Handler {
 		$filename .= $this->get_extension( wp_get_attachment_url( $attach->ID ) );
 		add_filter( 'wp_get_attachment_url', array( $this, 'attachment_url_filter' ), 10, 2 );
 
+		// Sanitize the filename for use in the Content-Disposition header to prevent header injection
+		// or quote-escape attacks via filterable extension/post slug values: strip any character that
+		// is not safe to appear inside an HTTP header value or inside a quoted-string filename param.
+		$filename = preg_replace( '/[\x00-\x1f"\\\\]/', '', (string) $filename );
+
 		$headers = array();
 
 		// Set content-disposition header. Two options here:
@@ -331,18 +336,46 @@ trait WP_Document_Revisions_File_Handler {
 		// Make sure that there is a buffer to be written on close.
 		ob_start( null, $buffsize );
 
-		// If we made it this far, just serve the file
-		// Note: We use readfile, and not WP_Filesystem for memory/performance reasons.
+		// If we made it this far, just serve the file.
 		if ( $compress ) {
-			if ( 'gzip' === $comp_type ) {
-				// phpcs:ignore WordPress.Security.EscapeOutput,WordPress.WP.AlternativeFunctions
-				echo gzencode( file_get_contents( $file ), 9 );
-				$headers['Content-Encoding'] = 'gzip';
+			// Stream the file through an incremental deflate context so the entire raw file
+			// is never resident in memory at once. The compressed bytes still accumulate in
+			// the output buffer (so we can populate Content-Length), but compressed size is
+			// typically << raw size for compressible payloads. Replaces the previous
+			// gzencode( file_get_contents( $file ) ) approach which loaded the entire file
+			// into PHP memory before compressing - a real DoS vector for multi-MB documents.
+			$encoding = ( 'gzip' === $comp_type ) ? ZLIB_ENCODING_GZIP : ZLIB_ENCODING_RAW;
+			$ctx      = deflate_init( $encoding, array( 'level' => 9 ) );
+			$fp       = @fopen( $file, 'rb' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+			if ( false === $ctx || false === $fp ) {
+				// Fallback path - avoid breaking download if streaming primitives fail.
+				if ( $fp ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+					fclose( $fp );
+				}
+				if ( 'gzip' === $comp_type ) {
+					// phpcs:ignore WordPress.Security.EscapeOutput,WordPress.WP.AlternativeFunctions
+					echo gzencode( file_get_contents( $file ), 9 );
+				} else {
+					// phpcs:ignore WordPress.Security.EscapeOutput,WordPress.WP.AlternativeFunctions
+					echo gzdeflate( file_get_contents( $file ), 9 );
+				}
 			} else {
-				// phpcs:ignore WordPress.Security.EscapeOutput,WordPress.WP.AlternativeFunctions
-				echo gzdeflate( file_get_contents( $file ), 9 );
-				$headers['Content-Encoding'] = 'deflate';
+				while ( ! feof( $fp ) ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread
+					$chunk = fread( $fp, 8192 );
+					if ( false === $chunk || '' === $chunk ) {
+						break;
+					}
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo deflate_add( $ctx, $chunk, ZLIB_NO_FLUSH );
+				}
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo deflate_add( $ctx, '', ZLIB_FINISH );
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+				fclose( $fp );
 			}
+			$headers['Content-Encoding'] = ( 'gzip' === $comp_type ) ? 'gzip' : 'deflate';
 			if ( array_key_exists( 'Content-Length', $headers ) ) {
 				// only update to the correct value.
 				$headers['Content-Length'] = ob_get_length();

--- a/includes/trait-wp-document-revisions-file-handler.php
+++ b/includes/trait-wp-document-revisions-file-handler.php
@@ -178,9 +178,10 @@ trait WP_Document_Revisions_File_Handler {
 		add_filter( 'wp_get_attachment_url', array( $this, 'attachment_url_filter' ), 10, 2 );
 
 		// Sanitize the filename for use in the Content-Disposition header to prevent header injection
-		// or quote-escape attacks via filterable extension/post slug values: strip any character that
-		// is not safe to appear inside an HTTP header value or inside a quoted-string filename param.
-		$filename = preg_replace( '/[\x00-\x1f"\\\\]/', '', (string) $filename );
+		// or quote-escape attacks via filterable extension/post slug values: strip control characters
+		// (including DEL, 0x7F) and characters that are unsafe inside an HTTP header value or quoted
+		// filename param.
+		$filename = preg_replace( '/[\x00-\x1f\x7f"\\\\]/', '', (string) $filename );
 
 		$headers = array();
 
@@ -336,6 +337,16 @@ trait WP_Document_Revisions_File_Handler {
 		// Make sure that there is a buffer to be written on close.
 		ob_start( null, $buffsize );
 
+		// Check file readability before committing to response headers (covers both branches:
+		// compressed streaming via fopen/deflate and uncompressed via readfile/WP_Filesystem).
+		if ( ! is_readable( $file ) ) {
+			status_header( 500 );
+			if ( $under_test ) {
+				return $template;
+			}
+			exit;
+		}
+
 		// If we made it this far, just serve the file.
 		if ( $compress ) {
 			// Stream the file through an incremental deflate context so the entire raw file
@@ -383,15 +394,6 @@ trait WP_Document_Revisions_File_Handler {
 			// only know the length after writing to buffer, so only output headers now.
 			$this->serve_headers( $headers, $file );
 		} else {
-			// Check file readability before committing to response headers.
-			if ( ! is_readable( $file ) ) {
-				status_header( 500 );
-				if ( $under_test ) {
-					return $template;
-				}
-				exit;
-			}
-
 			// know the headers and buffering may cause writing, so output headers first.
 			$this->serve_headers( $headers, $file );
 			// see if PHP readfile could be used.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -169,18 +169,6 @@ parameters:
 			path: includes/class-wp-document-revisions-front-end.php
 
 		-
-			message: '#^Undefined variable\: \$id$#'
-			identifier: variable.undefined
-			count: 3
-			path: includes/class-wp-document-revisions-front-end.php
-
-		-
-			message: '#^Undefined variable\: \$numberposts$#'
-			identifier: variable.undefined
-			count: 1
-			path: includes/class-wp-document-revisions-front-end.php
-
-		-
 			message: '#^Method WP_Document_Revisions_Recently_Revised_Widget\:\:update\(\) should return array but returns ArrayAccess\.$#'
 			identifier: return.type
 			count: 1

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -43,6 +43,13 @@ Domain Path: /languages
  *  @package WP_Document_Revisions
  *  @author Ben Balter <ben@balter.com>
  */
+// Single source of truth for the plugin version. The "Version:" header above is
+// parsed by WordPress from the file header itself and must remain literal; this
+// constant is the canonical value for runtime PHP code (cache busters, etc.).
+if ( ! defined( 'WPDR_VERSION' ) ) {
+	define( 'WPDR_VERSION', '4.0.4' );
+}
+
 require_once __DIR__ . '/includes/trait-wp-document-revisions-rewrites.php';
 require_once __DIR__ . '/includes/trait-wp-document-revisions-file-handler.php';
 require_once __DIR__ . '/includes/trait-wp-document-revisions-revisions.php';


### PR DESCRIPTION
Implements the highest-leverage concrete items from the deep-audit plan (`plan.md` in the linked session). Each finding is independently revertible.

## Changes

### Q-8 — Single version source of truth
`WPDR_VERSION` constant defined in the main plugin file. `WP_Document_Revisions::$version` now reads from it. The plugin-header `Version:` line stays literal because WordPress parses it from the file header itself; `readme.txt` Stable tag is left for release tooling. One fewer place to remember to bump.

### S-2 (partial) — Replace dynamic local-variable extraction
The `foreach … $$key = …` loop in `WP_Document_Revisions_Front_End::revisions_shortcode()` is replaced with explicit assignments for the only two attributes the function actually consumes (`$id`, `$numberposts`). The original loop created three other locals (`$show_thumb`, `$show_descr`, `$new_tab`) that were never read — the function reads those values via `$atts[...]` directly elsewhere. Behaviour is identical; static analysis is happier.

The two `__get` magic-accessor sites (`WP_Document_Revisions::$$name`) are intentionally **not** changed — converting them to an allowlist would risk breaking third-party extensions that pass-through arbitrary properties.

### P-2 — Streaming compressed downloads (HIGH)
`gzencode( file_get_contents( $file ), 9 )` and the deflate equivalent are replaced with chunked streaming via `deflate_init` / `deflate_add` (PHP 7.0+, plugin already requires 7.4). Previously the entire raw file was loaded into PHP memory before compression — a real DoS vector for multi-MB documents and an outright failure mode for files larger than the request memory limit. New implementation reads in 8 KB chunks; compressed output still passes through `ob_start` so the existing `Content-Length` logic is preserved. A defensive fallback retains the original `gzencode()` path if `deflate_init()` or `fopen()` fails.

### S-1 (partial) — Content-Disposition filename hardening (HIGH)
Strip control chars, double quotes, and backslashes from the generated filename before writing it into the `Content-Disposition` header. PHP's `header()` already blocks raw CRLF, but this is defense in depth against quote-escape via the `document_extension` filter or unusual post slugs.

## What's deferred
These remain in the audit backlog and warrant focused follow-up PRs:
- **S-1 deeper review** — path canonicalization, range-request support, HEAD handling
- **Q-1** — 108-entry PHPStan baseline triage
- **Q-2** — bump PHP minimum to 8.1+ (7.4 EOL)
- **Q-3 / Q-4** — split 1000+ line classes/traits
- **T-1, T-2, T-3** — coverage and E2E expansion

## Verification
- `npm test` — 5/5 suites, 370/370 tests pass
- `php -l` clean on all changed files (`php:8.2-cli`)
- PHPUnit `serve_file` tests exercise the uncompressed branch (no `Accept-Encoding` in the test harness), so the readfile path is unchanged. CI will validate PHPCS / PHPStan / PHPUnit / E2E end to end.

## Files changed
- `wp-document-revisions.php` — `WPDR_VERSION` constant
- `includes/class-wp-document-revisions.php` — `$version` reads constant
- `includes/class-wp-document-revisions-front-end.php` — explicit shortcode locals
- `includes/trait-wp-document-revisions-file-handler.php` — streaming compression + filename sanitization