### PR TITLE
Fix #497: Conditionally hide Description and Revision Summary meta boxes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,10 +15,10 @@
 }
 
 /* General document edit styling */
-#postdiv,
+/*#postdiv,
 #postdivrich {
 	display: none;
-}
+}*/
 
 #lock-notice {
 	background-color: #d4e8ba;
@@ -47,9 +47,9 @@
 	padding-bottom: 5px;
 }
 
-#revision-summary {
+/*#revision-summary {
 	display: none;
-}
+}*/
 
 #autosave-alert {
 	display: none;

--- a/includes/trait-wp-document-revisions-admin-editor.php
+++ b/includes/trait-wp-document-revisions-admin-editor.php
@@ -413,7 +413,7 @@ trait WP_Document_Revisions_Admin_Editor {
 				self::$last_revn_excerpt
 			);
 			$wpdb->query( $sql );
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery	
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery
 			wp_cache_delete( self::$last_revn, 'posts' );
 			wp_cache_delete( $doc_id, 'posts' );
 			clean_post_cache( self::$last_revn_excerpt );
@@ -478,7 +478,10 @@ trait WP_Document_Revisions_Admin_Editor {
 					'.post-type-document .editor-visual-editor,
 					.post-type-document .edit-post-visual-editor,
 					.post-type-document .editor-text-editor,
-					.post-type-document .edit-post-text-editor {
+					.post-type-document .edit-post-text-editor,
+				    #postdiv,
+					#postdivrich,
+					#revision-summary {
 						display: none !important;
 					}'
 				);


### PR DESCRIPTION
**Description**
Fixes #497 – The “Document Description” and “Revision Summary” meta boxes were invisible in the Classic Editor after version 4.0.4.
The root cause was two global CSS rules in css/style.css that unconditionally hid #postdiv, #postdivrich and #revision-summary. These rules were intended to clean up the Block Editor interface but were loaded on all editor pages.

**Solution**
Removed the global hiding rules from style.css and moved them into the Block‑Editor‑only inline style that is already conditionally enqueued when use_block_editor_for_post() is true. This scopes the hiding to the Block Editor only, restoring the classic editor’s essential fields.

**Changes Made**

css/style.css: Deleted the rules:

css
#postdiv, #postdivrich { display: none; }
#revision-summary { display: none; }
includes/trait-wp-document-revisions-admin-editor.php: Inside the if ( $use_block_editor ) block of the enqueue() method, extended the existing wp_add_inline_style call to include those three selectors, ensuring they remain hidden in the Block Editor but not elsewhere.

**Testing Instructions**

Ensure the plugin is active and the document_use_block_editor filter is false (the default).

Go to Documents → Add New (or edit an existing document).

Classic Editor: Verify that:

The “Document Description” editor (TinyMCE) is fully visible and editable.

The “Revision Summary” meta box is present and can be expanded.

(Optional) Temporarily enable the Block Editor by adding
add_filter( 'document_use_block_editor', '__return_true' );
and confirm that those same elements are hidden (the block editor uses the sidebar panels instead).

**Additional Notes**

No breaking changes – the Block Editor behaviour remains identical; the classic editor simply regains its missing fields.

Backward compatible with existing WordPress versions and editor configurations.

**Closes**: #497