### PR TITLE
Fix #494: restore attachment ID in post_content when classic-editor upload save fails

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 
 #### Bug Fixes
 
+* Fix #494: restore attachment ID in `post_content` when classic-editor upload save fails. Two root causes addressed: `wp_kses_post` stripping the `<!-- WPDR N -->` HTML comment for users without `unfiltered_html` (fixed via `restore_document_attachment_id` on `wp_insert_post_data`), and JS upload callback not firing leaving `post_content` empty (fixed via `save_document` fallback to `get_latest_attachment()`).
 * Fix PHP `TypeError` in `filter_from_media_grid()`: the `ajax_query_attachments_args` filter passes an `array`, not a `WP_Query` object, so the incorrect type hint caused a fatal error that prevented media library items from loading in the block editor.
 * Add WP Plugin Check compliance: phpcs ignore directives for non-prefixed hook names and other plugin-check messages.
 * Remove 252 PHPStan baseline suppressions by resolving the underlying type errors.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,30 @@
 
 Numbers in brackets show the issue number in https://github.com/wp-document-revisions/wp-document-revisions/issues/
 
+### 4.0.7
+
+#### Bug Fixes
+
+* Fix PHP `TypeError` in `filter_from_media_grid()`: the `ajax_query_attachments_args` filter passes an `array`, not a `WP_Query` object, so the incorrect type hint caused a fatal error that prevented media library items from loading in the block editor.
+* Add WP Plugin Check compliance: phpcs ignore directives for non-prefixed hook names and other plugin-check messages.
+* Remove 252 PHPStan baseline suppressions by resolving the underlying type errors.
+* Update filter/action documentation to reflect file-splitting of trait files.
+* Exclude build artifacts from distributed plugin package via `.distignore`.
+
+### 4.0.6
+
+#### Bug Fixes
+
+* Fix description field hidden in classic editor after 4.0.4: `#postdivrich` (the TinyMCE visual editor) was incorrectly added to the CSS `display:none` rule intended only for the HTML text tab (`#postdiv`).
+* Fix revision summary box not appearing: removed CSS `display:none` on `#revision-summary` since JavaScript already manages its visibility; the stale CSS rule prevented it from appearing when TinyMCE failed to initialise.
+
+### 4.0.5
+
+#### Bug Fixes
+
+* Fix PHP fatal error in `suppress_adjacent_doc()` when WordPress passes `$excluded_terms` as a string instead of an array.
+* Fix PHP fatal error in `image_downsize()` when WordPress passes `$id` as a string instead of an int.
+
 ### 4.0.4
 
 #### Security

--- a/docs/header.md
+++ b/docs/header.md
@@ -5,7 +5,7 @@ Tags: documents, document management, version control, collaboration, revisions
 Requires at least: 5.0
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 4.0.4
+Stable tag: 4.0.7
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -73,6 +73,7 @@ class WP_Document_Revisions_Admin {
 		add_action( 'admin_head', array( $this, 'make_private' ), 20 );
 		add_action( 'set_object_terms', array( $this, 'workflow_state_save' ), 10, 6 );
 		add_action( 'save_post_document', array( $this, 'save_document' ) );
+		add_filter( 'wp_insert_post_data', array( $this, 'restore_document_attachment_id' ), 10, 2 );
 		add_action( 'admin_init', array( $this, 'enqueue_edit_scripts' ) );
 		add_action( '_wp_put_post_revision', array( $this, 'revision_filter' ), 10, 1 );
 		add_filter( 'wp_save_post_revision_post_has_changed', array( $this, 'identify_last_but_one' ), 10, 3 );

--- a/includes/trait-wp-document-revisions-admin-editor.php
+++ b/includes/trait-wp-document-revisions-admin-editor.php
@@ -343,6 +343,55 @@ trait WP_Document_Revisions_Admin_Editor {
 
 
 	/**
+	 * Restores the WPDR attachment ID comment to post_content when it has been stripped
+	 * by wp_kses_post (applied via content_save_pre for users without unfiltered_html).
+	 *
+	 * This filter runs after content_save_pre but before the DB write, so it can patch
+	 * the data in-place without a secondary wp_update_post call.
+	 *
+	 * @since 4.0.8
+	 * @param array $data    Sanitized post data about to be inserted.
+	 * @param array $postarr Raw post data passed to wp_insert_post.
+	 * @return array Post data, with post_content restored if needed.
+	 */
+	public function restore_document_attachment_id( array $data, array $postarr ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		if ( 'document' !== $data['post_type'] ) {
+			return $data;
+		}
+
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return $data;
+		}
+
+		// Already has an attachment ID — nothing to fix.
+		if ( $this->extract_document_id( $data['post_content'] ) ) {
+			return $data;
+		}
+
+		// The WPDR comment may have been stripped by wp_kses_post.  The raw form value is
+		// still in $_POST['post_content'] (unfiltered superglobal).
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( ! isset( $_POST['post_content'] ) ) {
+			return $data;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$raw_posted = wp_unslash( $_POST['post_content'] );
+		$attach_id  = $this->extract_document_id( $raw_posted );
+
+		if ( ! $attach_id ) {
+			return $data;
+		}
+
+		// Rebuild: attachment ID comment + any description that survived kses.
+		$description          = preg_replace( '/<!--\s*WPDR\s*\d+\s*-->/i', '', $data['post_content'] );
+		$data['post_content'] = $this->format_doc_id( $attach_id ) . $description;
+
+		return $data;
+	}
+
+
+	/**
 	 * Callback to unlink loaded featured image.
 	 *
 	 * @since 3.3
@@ -384,6 +433,32 @@ trait WP_Document_Revisions_Admin_Editor {
 		// find the attachment id now (as content might be cached) and we might delete the cache.
 		$content   = get_post_field( 'post_content', $doc_id );
 		$attach_id = $this->extract_document_id( $content );
+
+		// Fallback: if no attachment ID reached the DB (JS failed to set the hidden field, or
+		// wp_kses_post stripped the WPDR comment for low-privilege users), try to recover from
+		// the most recently uploaded attachment for this document.
+		if ( ! $attach_id ) {
+			$latest_attach = $this->get_latest_attachment( $doc_id );
+			if ( $latest_attach ) {
+				// Preserve any existing description text, but restore the attachment ID comment.
+				$description = preg_replace( '/<!--\s*WPDR\s*\d+\s*-->/i', '', $content );
+				$new_content = $this->format_doc_id( $latest_attach->ID ) . $description;
+				global $wpdb;
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery
+				$post_table = "{$wpdb->prefix}posts";
+				$wpdb->query(
+					$wpdb->prepare(
+						"UPDATE `$post_table` SET `post_content` = %s WHERE `ID` = %d",
+						$new_content,
+						$doc_id
+					)
+				);
+				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery
+				wp_cache_delete( $doc_id, 'posts' );
+				clean_post_cache( $doc_id );
+				$attach_id = $latest_attach->ID;
+			}
+		}
 
 		// Let's work on Workflow state, Verify nonce.
 		if ( ! isset( $_POST['workflow_state_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['workflow_state_nonce'] ) ), 'wp-document-revisions' ) ) {

--- a/includes/trait-wp-document-revisions-admin-editor.php
+++ b/includes/trait-wp-document-revisions-admin-editor.php
@@ -375,7 +375,7 @@ trait WP_Document_Revisions_Admin_Editor {
 			return $data;
 		}
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- raw value needed; wp_kses_post() strips the HTML comment we're extracting. Only an integer is extracted from this string.
 		$raw_posted = wp_unslash( $_POST['post_content'] );
 		$attach_id  = $this->extract_document_id( $raw_posted );
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27,13 +27,13 @@ parameters:
 		-
 			message: '#^Call to an undefined method WP_Document_Revisions_Admin\:\:extract_document_id\(\)\.$#'
 			identifier: method.notFound
-			count: 1
+			count: 3
 			path: includes/class-wp-document-revisions-admin.php
 
 		-
 			message: '#^Call to an undefined method WP_Document_Revisions_Admin\:\:format_doc_id\(\)\.$#'
 			identifier: method.notFound
-			count: 3
+			count: 5
 			path: includes/class-wp-document-revisions-admin.php
 
 		-

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: documents, document management, version control, collaboration, revisions
 Requires at least: 5.0
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 4.0.6
+Stable tag: 4.0.7
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -110,48 +110,6 @@ See [**the full list of features**](https://wp-document-revisions.github.io/wp-d
 - **WPML Support** - Integration with WPML
 
 
-== Useful plugins and tools ==
-
-= Permissions management =
-
-- [Members - Membership & User Role Editor Plugin](https://wordpress.org/plugins/members/)
-
-  (Previously called Members)
-
-= Taxonomy management =
-
-- [Simple Taxonomy Refreshed](https://wordpress.org/plugins/simple-taxonomy-refreshed/)
-
-= Email notification and distribution =
-
-- [Email Notice for WP Document Revisions](https://wordpress.org/plugins/email-notice-wp-document-revisions/)
-
-= Document workflow management =
-
-- [Edit Flow](https://wordpress.org/plugins/edit-flow/)
-- [PublishPress Statuses](https://wordpress.org/plugins/publishpress-statuses/)
-- [PublishPress Revisions](https://wp-document-revisions.github.io/wp-document-revisions/https://wordpress.org/plugins/publishpress-revisions/) - See the [integration guide](cookbook/publishpress-revisions-integration/) for scheduling document revisions
-
-
-== Screenshots ==
-
-\###1. A typical WP Document Revisions edit document screen.###
-
-![A typical WP Document Revisions edit document screen.](https://raw.githubusercontent.com/wp-document-revisions/wp-document-revisions/master/screenshot-1.png)
-
-
-== Links ==
-
-- **[Source Code](https://github.com/wp-document-revisions/wp-document-revisions/)** (GitHub)
-- **[Latest Release](https://github.com/wp-document-revisions/wp-document-revisions/releases/latest)** - Download the newest version
-- **[WordPress.org Plugin Page](https://wordpress.org/plugins/wp-document-revisions/)** - Official plugin listing
-- **[Development Version](https://github.com/wp-document-revisions/wp-document-revisions/tree/develop)** ([CI Status](https://github.com/wp-document-revisions/wp-document-revisions/actions/workflows/ci.yml))
-- **[Code Cookbook](https://github.com/wp-document-revisions/wp-document-revisions-Code-Cookbook)** - Code examples and customizations
-- **[Translations](https://crowdin.com/project/wordpress-document-revisions)** (Crowdin)
-- **[Where to get Support or Report an Issue](https://wp-document-revisions.github.io/wp-document-revisions/SUPPORT/)** - Get help when you need it
-- **[How to Contribute](https://wp-document-revisions.github.io/wp-document-revisions/CONTRIBUTING/)** - Join our community
-
-
 == Installation ==
 
 = 🚀 Automatic Install (Recommended) =
@@ -195,6 +153,25 @@ After installation, you'll find a new **Documents** menu in your WordPress admin
 Need help? Check our [FAQ](https://wp-document-revisions.github.io/wp-document-revisions/frequently-asked-questions/) or [get support](https://wp-document-revisions.github.io/wp-document-revisions/SUPPORT/).
 
 
+== Links ==
+
+- **[Source Code](https://github.com/wp-document-revisions/wp-document-revisions/)** (GitHub)
+- **[Latest Release](https://github.com/wp-document-revisions/wp-document-revisions/releases/latest)** - Download the newest version
+- **[WordPress.org Plugin Page](https://wordpress.org/plugins/wp-document-revisions/)** - Official plugin listing
+- **[Development Version](https://github.com/wp-document-revisions/wp-document-revisions/tree/develop)** ([CI Status](https://github.com/wp-document-revisions/wp-document-revisions/actions/workflows/ci.yml))
+- **[Code Cookbook](https://github.com/wp-document-revisions/wp-document-revisions-Code-Cookbook)** - Code examples and customizations
+- **[Translations](https://crowdin.com/project/wordpress-document-revisions)** (Crowdin)
+- **[Where to get Support or Report an Issue](https://wp-document-revisions.github.io/wp-document-revisions/SUPPORT/)** - Get help when you need it
+- **[How to Contribute](https://wp-document-revisions.github.io/wp-document-revisions/CONTRIBUTING/)** - Join our community
+
+
+== Screenshots ==
+
+\###1. A typical WP Document Revisions edit document screen.###
+
+![A typical WP Document Revisions edit document screen.](https://raw.githubusercontent.com/wp-document-revisions/wp-document-revisions/master/screenshot-1.png)
+
+
 == Translations ==
 
 Interested in translating WP Document Revisions? You can do so [via Crowdin](https://crowdin.com/project/wordpress-document-revisions), or by submitting a pull request.
@@ -211,42 +188,50 @@ Interested in translating WP Document Revisions? You can do so [via Crowdin](htt
 - Dutch - @tijscruysen
 
 
+== Useful plugins and tools ==
+
+= Permissions management =
+
+- [Members - Membership & User Role Editor Plugin](https://wordpress.org/plugins/members/)
+
+  (Previously called Members)
+
+= Taxonomy management =
+
+- [Simple Taxonomy Refreshed](https://wordpress.org/plugins/simple-taxonomy-refreshed/)
+
+= Email notification and distribution =
+
+- [Email Notice for WP Document Revisions](https://wordpress.org/plugins/email-notice-wp-document-revisions/)
+
+= Document workflow management =
+
+- [Edit Flow](https://wordpress.org/plugins/edit-flow/)
+- [PublishPress Statuses](https://wordpress.org/plugins/publishpress-statuses/)
+- [PublishPress Revisions](https://wp-document-revisions.github.io/wp-document-revisions/https://wordpress.org/plugins/publishpress-revisions/) - See the [integration guide](cookbook/publishpress-revisions-integration/) for scheduling document revisions
+
+
 == Changelog ==
 
 Numbers in brackets show the issue number in https://github.com/wp-document-revisions/wp-document-revisions/issues/
 
+= 4.0.7 =
+
+= # Bug Fixes =
+
+* Fix PHP `TypeError` in `filter_from_media_grid()`: the `ajax_query_attachments_args` filter passes an `array`, not a `WP_Query` object, so the incorrect type hint caused a fatal error that prevented media library items from loading in the block editor.
+* Add WP Plugin Check compliance: phpcs ignore directives for non-prefixed hook names and other plugin-check messages.
+* Remove 252 PHPStan baseline suppressions by resolving the underlying type errors.
+* Update filter/action documentation to reflect file-splitting of trait files.
+* Exclude build artifacts from distributed plugin package via `.distignore`.
+
 = 4.0.6 =
+
+= # Bug Fixes =
 
 * Fix description field hidden in classic editor after 4.0.4: `#postdivrich` (the TinyMCE visual editor) was incorrectly added to the CSS `display:none` rule intended only for the HTML text tab (`#postdiv`).
 * Fix revision summary box not appearing: removed CSS `display:none` on `#revision-summary` since JavaScript already manages its visibility; the stale CSS rule prevented it from appearing when TinyMCE failed to initialise.
 
 = 4.0.5 =
-
-* Fix PHP fatal error in `suppress_adjacent_doc()` when WordPress passes `$excluded_terms` as a string instead of an array.
-* Fix PHP fatal error in `image_downsize()` when WordPress passes `$id` as a string instead of an int.
-
-= 4.0.4 =
-
-= # Security =
-
-* Fix authentication bypass in revision feed key validation (`validate_feed_key()`) where `$wpdb->get_var()` returning NULL was treated as a successful match.
-* Fix variable shadowing in validate-structure REST `correct_document()` (code 4) that could overwrite the `post_content` of an unrelated post.
-* Add per-document capability checks to Abilities API endpoints `override-document-lock` and `get-document-revisions`.
-* Sanitize the `revision` query var (`absint()`) before concatenation into the `Content-Disposition` filename header in `serve_file()`.
-
-= 4.0.3 =
-
-= # Bug Fixes =
-
-* Restore plugin banner image for WordPress.org plugin page
-* Add required `== Description ==` section header to readme.txt
-
-= 4.0.2 =
-
-= # Bug Fixes =
-
-* Fix WordPress Playground `blueprint.json` path and schema for WordPress.org Live Preview
-
-= 4.0.1 =
 
 For complete changelog, see [GitHub](https://wp-document-revisions.github.io/wp-document-revisions/changelog/)

--- a/readme.txt
+++ b/readme.txt
@@ -219,6 +219,7 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 
 = # Bug Fixes =
 
+* Fix #494: restore attachment ID in `post_content` when classic-editor upload save fails. Two root causes addressed: `wp_kses_post` stripping the `<!-- WPDR N -->` HTML comment for users without `unfiltered_html` (fixed via `restore_document_attachment_id` on `wp_insert_post_data`), and JS upload callback not firing leaving `post_content` empty (fixed via `save_document` fallback to `get_latest_attachment()`).
 * Fix PHP `TypeError` in `filter_from_media_grid()`: the `ajax_query_attachments_args` filter passes an `array`, not a `WP_Query` object, so the incorrect type hint caused a fatal error that prevented media library items from loading in the block editor.
 * Add WP Plugin Check compliance: phpcs ignore directives for non-prefixed hook names and other plugin-check messages.
 * Remove 252 PHPStan baseline suppressions by resolving the underlying type errors.

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Document Revisions
 Plugin URI: http://ben.balter.com/2011/08/29/wp-document-revisions-document-management-version-control-wordpress/
 Description: A document management and version control plugin for WordPress that allows teams of any size to collaboratively edit files and manage their workflow.
-Version: 4.0.6
+Version: 4.0.7
 Requires at least: 5.0
 Requires PHP: 7.4
 Author: Ben Balter
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  *  @copyright 2011-2025
  *  @license GPL-3.0-or-later
- *  @version 4.0.6
+ *  @version 4.0.7
  *  @package WP_Document_Revisions
  *  @author Ben Balter <ben@balter.com>
  */
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // parsed by WordPress from the file header itself and must remain literal; this
 // constant is the canonical value for runtime PHP code (cache busters, etc.).
 if ( ! defined( 'WPDR_VERSION' ) ) {
-	define( 'WPDR_VERSION', '4.0.6' );
+	define( 'WPDR_VERSION', '4.0.7' );
 }
 
 require_once __DIR__ . '/includes/trait-wp-document-revisions-rewrites.php';


### PR DESCRIPTION
## Summary

Fixes #494 — after uploading a document via the classic-editor ThickBox flow, `post_content` was never populated with the attachment ID, so the file could not be served.

Two root causes were identified and addressed with complementary PHP-side safeguards:

**Root cause 1 — `wp_kses_post` stripping the WPDR comment**
WordPress applies `content_save_pre` → `wp_filter_post_kses` for users without the `unfiltered_html` capability (contributors, authors). This silently strips `<!-- WPDR N -->` HTML comments from `post_content` on every save.

**Root cause 2 — JS upload callback not firing**
`bindPostDocumentUploadCB()` silently returns early when `window.uploader` (the Plupload instance) is not yet defined at call time. If the retry on `window.load` also misses it, the hidden `#post_content` field is never updated, so `$_POST['post_content']` arrives empty.

## Fixes

**`restore_document_attachment_id` (`wp_insert_post_data` filter)**
Runs after `content_save_pre` but before the DB write. If `post_content` has no attachment ID after kses filtering, reads the raw `$_POST['post_content']` superglobal (unfiltered), extracts the integer ID, and rebuilds `post_content` in-place. No secondary save or extra revision needed. Covers root cause 1.

**`save_document` fallback**
After the initial save, if `post_content` in the DB still has no attachment ID (JS completely failed — `$_POST['post_content']` was also empty), looks up the most recently uploaded attachment via `get_latest_attachment()` and writes the corrected `post_content` directly to the DB, preserving any description text. Covers root cause 2.

## Test plan

- [ ] As an **administrator**, upload a document via the classic editor ThickBox — attachment ID appears in the revision log and the file downloads correctly
- [ ] As a **contributor** (no `unfiltered_html`), upload a document — `post_content` contains `<!-- WPDR N -->` after save (previously stripped by kses)
- [ ] Upload a file, then immediately click **Save** before the 1-second `checkUpdate` interval fires — file is still served correctly
- [ ] Edit an existing document's description without uploading — existing attachment ID and description are preserved
- [ ] Existing PHPUnit test suite passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)