### PR TITLE
Add smalot/pdfparser dep and scoped-autoload shim (#514, phase 3a)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -22,6 +22,11 @@ bin
 circle.yml
 composer.json
 composer.lock
+# Note: `vendor` is intentionally NOT excluded — smalot/pdfparser and its
+# dependencies are installed via `composer install --no-dev` in the deploy
+# workflow and ship to wordpress.org from there. When the scoper pipeline
+# moves onto the release path, swap to excluding `vendor` and shipping
+# `vendor-prefixed/` instead.
 crowdin.yml
 docker-compose.yml
 Gruntfile.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
               # produced an output directory.
               run: |
                   php -r '
-                      require __DIR__ . "/vendor-prefixed/scoper-autoload.php";
+                      require __DIR__ . "/vendor-prefixed/autoload.php";
                       if (!class_exists("WP_Document_Revisions\\Vendor\\Smalot\\PdfParser\\Parser")) {
                           fwrite(STDERR, "Scoped PdfParser class is not autoloadable\n");
                           exit(1);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,23 +35,17 @@ jobs:
             - name: Install dependencies
               run: composer install --prefer-dist --no-progress
 
-            - name: phpcs
-              run: script/cibuild-phpcs
-
-            - name: PHPStan
-              run: php -d memory_limit=-1 bin/phpstan analyse --configuration=phpstan.neon.dist --no-progress
-
             - name: Audit dependencies
               run: composer audit
 
             - name: Validate scoper config (php -l)
               run: php -l scoper.inc.php
 
-            - name: Install php-scoper
-              run: composer install --working-dir=vendor-bin/scoper --no-progress --no-interaction
+            - name: phpcs
+              run: script/cibuild-phpcs
 
-            - name: Verify php-scoper is callable
-              run: vendor-bin/scoper/vendor/bin/php-scoper --version
+            - name: PHPStan
+              run: php -d memory_limit=-1 bin/phpstan analyse --configuration=phpstan.neon.dist --no-progress
 
     # End-to-end smoke test for the scoper build pipeline. Runs in its own
     # job because it needs `composer install --no-dev`, which would remove
@@ -82,6 +76,14 @@ jobs:
                       exit 1
                   fi
                   ls -la vendor-prefixed
+
+            - name: Verify scoped class is autoloadable
+              # End-to-end check that the prefix actually rewrote the
+              # production dependency's namespaces — not just that scoper
+              # produced an output directory.
+              run: |
+                  php -r 'require __DIR__ . "/vendor-prefixed/scoper-autoload.php";' \
+                      -r 'if (!class_exists("WP_Document_Revisions\\Vendor\\Smalot\\PdfParser\\Parser")) { fwrite(STDERR, "Scoped PdfParser class is not autoloadable\n"); exit(1); }'
 
     jest:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,13 @@ jobs:
               # production dependency's namespaces — not just that scoper
               # produced an output directory.
               run: |
-                  php -r 'require __DIR__ . "/vendor-prefixed/scoper-autoload.php";' \
-                      -r 'if (!class_exists("WP_Document_Revisions\\Vendor\\Smalot\\PdfParser\\Parser")) { fwrite(STDERR, "Scoped PdfParser class is not autoloadable\n"); exit(1); }'
+                  php -r '
+                      require __DIR__ . "/vendor-prefixed/scoper-autoload.php";
+                      if (!class_exists("WP_Document_Revisions\\Vendor\\Smalot\\PdfParser\\Parser")) {
+                          fwrite(STDERR, "Scoped PdfParser class is not autoloadable\n");
+                          exit(1);
+                      }
+                  '
 
     jest:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,28 +70,17 @@ jobs:
               run: composer build:scope
 
             - name: Verify vendor-prefixed/ was produced
+              # Scoper still runs in CI as a smoke check that the build
+              # pipeline itself is wired up correctly, even though the
+              # release does not ship vendor-prefixed/ yet. When scoping is
+              # promoted onto the release path, this step gains a follow-up
+              # that asserts the scoped class is autoloadable.
               run: |
                   if [ ! -d vendor-prefixed ]; then
                       echo "vendor-prefixed/ was not created by build:scope" >&2
                       exit 1
                   fi
                   ls -la vendor-prefixed
-
-            - name: Verify scoped class is autoloadable
-              # End-to-end check that the prefix actually rewrote the
-              # production dependency's namespaces — not just that scoper
-              # produced an output directory.
-              run: |
-                  php -r '
-                      $autoload = file_exists(__DIR__ . "/vendor-prefixed/scoper-autoload.php")
-                          ? __DIR__ . "/vendor-prefixed/scoper-autoload.php"
-                          : __DIR__ . "/vendor-prefixed/autoload.php";
-                      require $autoload;
-                      if (!class_exists("WP_Document_Revisions\\Vendor\\Smalot\\PdfParser\\Parser")) {
-                          fwrite(STDERR, "Scoped PdfParser class is not autoloadable\n");
-                          exit(1);
-                      }
-                  '
 
     jest:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,10 @@ jobs:
               # produced an output directory.
               run: |
                   php -r '
-                      require __DIR__ . "/vendor-prefixed/autoload.php";
+                      $autoload = file_exists(__DIR__ . "/vendor-prefixed/scoper-autoload.php")
+                          ? __DIR__ . "/vendor-prefixed/scoper-autoload.php"
+                          : __DIR__ . "/vendor-prefixed/autoload.php";
+                      require $autoload;
                       if (!class_exists("WP_Document_Revisions\\Vendor\\Smalot\\PdfParser\\Parser")) {
                           fwrite(STDERR, "Scoped PdfParser class is not autoloadable\n");
                           exit(1);

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,16 +32,11 @@ jobs:
 
             - name: Install production composer dependencies
               # Production deps only — no dev tools in the release artifact.
+              # smalot/pdfparser ships unscoped from vendor/ for now; the
+              # scoper pipeline exists (composer build:scope) but is not on
+              # the release path until the Composer-autoload bootstrap edge
+              # cases are worked out. See scoper.inc.php and issue #514.
               run: composer install --no-dev --no-progress --no-interaction
-
-            - name: Build scoped vendor
-              # Rewrites the production composer dependencies into
-              # vendor-prefixed/ under the WP_Document_Revisions\Vendor\
-              # namespace so they cannot collide with the same libraries
-              # shipped by another wordpress.org plugin. The 10up action
-              # ships vendor-prefixed/ (not excluded in .distignore) and
-              # excludes vendor/ + composer.* via the existing .distignore.
-              run: composer build:scope
 
             - name: WordPress Plugin Deploy
               uses: 10up/action-wordpress-plugin-deploy@stable

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,26 @@ jobs:
                   node-version: '20'
                   cache: 'npm'
 
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.2'
+
             - name: Build assets
               run: npm ci && npm run build
+
+            - name: Install production composer dependencies
+              # Production deps only — no dev tools in the release artifact.
+              run: composer install --no-dev --no-progress --no-interaction
+
+            - name: Build scoped vendor
+              # Rewrites the production composer dependencies into
+              # vendor-prefixed/ under the WP_Document_Revisions\Vendor\
+              # namespace so they cannot collide with the same libraries
+              # shipped by another wordpress.org plugin. The 10up action
+              # ships vendor-prefixed/ (not excluded in .distignore) and
+              # excludes vendor/ + composer.* via the existing .distignore.
+              run: composer build:scope
 
             - name: WordPress Plugin Deploy
               uses: 10up/action-wordpress-plugin-deploy@stable

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,10 @@
 			"email": "ben@balter.com"
 		}
 	],
-	"require": {},
+	"require": {
+		"php": ">=7.4",
+		"smalot/pdfparser": "^2.10"
+	},
 	"require-dev": {
 		"phpcsstandards/phpcsutils": "^1.1",
 		"phpcsstandards/phpcsextra": "^1.4",

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -90,7 +90,7 @@ The pipeline lives at:
 - `composer.json` — declares the `build:scope` script and the production `require` entries.
 - `vendor-bin/scoper/composer.json` — isolated manifest pinning `humbug/php-scoper`, installed via `composer install --working-dir=vendor-bin/scoper`. Lives in its own subdirectory so scoper's own dependencies cannot conflict with the main `vendor/` tree.
 - `scoper.inc.php` — prefix, finders, patchers, exposers.
-- `wp-document-revisions.php` — picks `vendor-prefixed/autoload.php` when present, falls back to `vendor/autoload.php`, and registers a `class_alias` shim so plugin source code can always reference the scoped names regardless of which autoload is active.
+- `wp-document-revisions.php` — picks `vendor-prefixed/scoper-autoload.php` (php-scoper 0.19+) or `vendor-prefixed/autoload.php` (older scoper) when present, falls back to `vendor/autoload.php`, and registers a `class_alias` shim so plugin source code can always reference the scoped names regardless of which autoload is active.
 
 ### Dev workflow
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -81,37 +81,21 @@ At a high level, [the process for proposing changes](https://guides.github.com/i
 
 `script/cibuild`
 
-## Scoped PHP dependencies
+## Production composer dependencies
 
-Production composer dependencies (currently `smalot/pdfparser`, with more landing as [issue #514](https://github.com/wp-document-revisions/wp-document-revisions/issues/514) progresses) are rewritten under `WP_Document_Revisions\Vendor\` via [php-scoper](https://github.com/humbug/php-scoper) so they cannot collide with the same library shipped by another wordpress.org plugin.
-
-The pipeline lives at:
-
-- `composer.json` — declares the `build:scope` script and the production `require` entries.
-- `vendor-bin/scoper/composer.json` — isolated manifest pinning `humbug/php-scoper`, installed via `composer install --working-dir=vendor-bin/scoper`. Lives in its own subdirectory so scoper's own dependencies cannot conflict with the main `vendor/` tree.
-- `scoper.inc.php` — prefix, finders, patchers, exposers.
-- `wp-document-revisions.php` — picks `vendor-prefixed/scoper-autoload.php` (php-scoper 0.19+) or `vendor-prefixed/autoload.php` (older scoper) when present, falls back to `vendor/autoload.php`, and registers a `class_alias` shim so plugin source code can always reference the scoped names regardless of which autoload is active.
+The plugin uses [`smalot/pdfparser`](https://github.com/smalot/pdfparser) for PDF text extraction (see [issue #514](https://github.com/wp-document-revisions/wp-document-revisions/issues/514)). It is installed via `composer install --no-dev` and ships unscoped from `vendor/` to wordpress.org today.
 
 ### Dev workflow
 
-After every `composer install`, run:
-
-```sh
-composer build:scope    # produces vendor-prefixed/ from the current vendor/ tree
-```
-
-Without it, phpstan will error because `vendor-prefixed/scoper-autoload.php` is listed as a bootstrap file in `phpstan.neon.dist`. The runtime alias shim means the plugin itself still loads in dev without `vendor-prefixed/` — only static analysis requires it.
+A plain `composer install` is enough — both dev tools and production deps land in `vendor/`, and `wp-document-revisions.php` boots from `vendor/autoload.php`.
 
 ### Release workflow
 
-The deploy workflow (`.github/workflows/deploy.yml`) runs the same two steps before invoking the WordPress.org deploy action:
+The deploy workflow (`.github/workflows/deploy.yml`) runs `composer install --no-dev` before invoking the WordPress.org deploy action so the release artifact contains only production deps in `vendor/`. `.distignore` is set up so `vendor/` ships and `composer.json` / `composer.lock` do not.
 
-```sh
-composer install --no-dev --no-progress
-composer build:scope
-```
+### Optional: scoped vendor (work in progress)
 
-`vendor-prefixed/` is gitignored but **not** in `.distignore`, so it ships in the wordpress.org artifact. The unscoped `vendor/` and the `composer.*` manifests are excluded by `.distignore` so only the scoped tree reaches end users.
+A php-scoper pipeline (`composer build:scope`, `scoper.inc.php`, `vendor-bin/scoper/`) is in place so that production composer deps can be rewritten under `WP_Document_Revisions\Vendor\` and avoid namespace collisions with the same library shipped by another wordpress.org plugin. The pipeline runs in CI as a smoke check but is **not on the release path yet** — php-scoper's handling of Composer's own autoload bootstrap needs more work before the scoped output is safe to load. When that work lands, `wp-document-revisions.php` already prefers `vendor-prefixed/` when it exists, and the deploy workflow will switch to running `composer build:scope` after the production install.
 
 ## Continuous Integration and Security
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -83,22 +83,35 @@ At a high level, [the process for proposing changes](https://guides.github.com/i
 
 ## Scoped PHP dependencies
 
-When the plugin gains production composer dependencies (e.g. `smalot/pdfparser` for PDF text extraction in [issue #514](https://github.com/wp-document-revisions/wp-document-revisions/issues/514)), their namespaces are rewritten under `WP_Document_Revisions\Vendor\` via [php-scoper](https://github.com/humbug/php-scoper) so they cannot collide with the same library shipped by another wordpress.org plugin.
+Production composer dependencies (currently `smalot/pdfparser`, with more landing as [issue #514](https://github.com/wp-document-revisions/wp-document-revisions/issues/514) progresses) are rewritten under `WP_Document_Revisions\Vendor\` via [php-scoper](https://github.com/humbug/php-scoper) so they cannot collide with the same library shipped by another wordpress.org plugin.
 
 The pipeline lives at:
 
-- `composer.json` — declares the `build:scope` script.
+- `composer.json` — declares the `build:scope` script and the production `require` entries.
 - `vendor-bin/scoper/composer.json` — isolated manifest pinning `humbug/php-scoper`, installed via `composer install --working-dir=vendor-bin/scoper`. Lives in its own subdirectory so scoper's own dependencies cannot conflict with the main `vendor/` tree.
 - `scoper.inc.php` — prefix, finders, patchers, exposers.
+- `wp-document-revisions.php` — picks `vendor-prefixed/scoper-autoload.php` when present, falls back to `vendor/autoload.php`, and registers a `class_alias` shim so plugin source code can always reference the scoped names regardless of which autoload is active.
 
-Local workflow for a release build:
+### Dev workflow
+
+After every `composer install`, run:
 
 ```sh
-composer install --no-dev --no-progress    # production composer deps only
-composer build:scope                        # runs php-scoper into vendor-prefixed/
+composer build:scope    # produces vendor-prefixed/ from the current vendor/ tree
 ```
 
-`vendor-prefixed/` is gitignored. It is generated at release time and bundled into the wordpress.org artifact instead of `vendor/`. The deploy workflow's integration with this pipeline lands alongside the first real production dependency in phase 3 of issue #514 — until then, `composer build:scope` runs in CI as a smoke test (validates `scoper.inc.php` syntactically and confirms `php-scoper` is installable) but does not produce a shipped artifact.
+Without it, phpstan will error because `vendor-prefixed/scoper-autoload.php` is listed as a bootstrap file in `phpstan.neon.dist`. The runtime alias shim means the plugin itself still loads in dev without `vendor-prefixed/` — only static analysis requires it.
+
+### Release workflow
+
+The deploy workflow (`.github/workflows/deploy.yml`) runs the same two steps before invoking the WordPress.org deploy action:
+
+```sh
+composer install --no-dev --no-progress
+composer build:scope
+```
+
+`vendor-prefixed/` is gitignored but **not** in `.distignore`, so it ships in the wordpress.org artifact. The unscoped `vendor/` and the `composer.*` manifests are excluded by `.distignore` so only the scoped tree reaches end users.
 
 ## Continuous Integration and Security
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -90,7 +90,7 @@ The pipeline lives at:
 - `composer.json` — declares the `build:scope` script and the production `require` entries.
 - `vendor-bin/scoper/composer.json` — isolated manifest pinning `humbug/php-scoper`, installed via `composer install --working-dir=vendor-bin/scoper`. Lives in its own subdirectory so scoper's own dependencies cannot conflict with the main `vendor/` tree.
 - `scoper.inc.php` — prefix, finders, patchers, exposers.
-- `wp-document-revisions.php` — picks `vendor-prefixed/scoper-autoload.php` when present, falls back to `vendor/autoload.php`, and registers a `class_alias` shim so plugin source code can always reference the scoped names regardless of which autoload is active.
+- `wp-document-revisions.php` — picks `vendor-prefixed/autoload.php` when present, falls back to `vendor/autoload.php`, and registers a `class_alias` shim so plugin source code can always reference the scoped names regardless of which autoload is active.
 
 ### Dev workflow
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,7 +6,9 @@ parameters:
     excludePaths:
         - vendor/
         - vendor-bin/
-        - vendor-prefixed/
+        # vendor-prefixed/ only exists after `composer build:scope`; tolerate
+        # its absence so plain `composer install` + phpstan works in dev.
+        - vendor-prefixed/ (?)
     bootstrapFiles:
         - vendor/autoload.php
     ignoreErrors: []

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,6 +5,8 @@ parameters:
         - includes/
     excludePaths:
         - vendor/
+        - vendor-bin/
+        - vendor-prefixed/
     bootstrapFiles:
         - vendor/autoload.php
     ignoreErrors: []

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -31,12 +31,21 @@ return array(
 			->in( 'vendor' ),
 	),
 
-	// Patchers, exposers, and excludes will be added alongside the first
-	// real dependency in phase 3 (smalot/pdfparser) — empty defaults are
-	// fine for the empty-vendor smoke test that runs in Phase 2.
 	'patchers' => array(),
 
-	'exclude-namespaces' => array(),
+	'exclude-namespaces' => array(
+		// Leave Composer's own autoload machinery unscoped. If we let
+		// scoper rewrite it, vendor-prefixed/composer/autoload_real.php
+		// ends up referencing `WP_Document_Revisions\Vendor\Composer\
+		// Autoload\ClassLoader` but the ClassLoader.php file scoper
+		// produces is loaded by file path before that name resolves,
+		// and the result is "class not found" at boot. Excluding the
+		// `Composer\` namespace from scoping keeps the bootstrap
+		// internally consistent — the scoped deps still get prefixed
+		// via the classmap entries scoper rewrites in
+		// autoload_classmap.php.
+		'Composer\\',
+	),
 	'exclude-classes'    => array(),
 	'exclude-functions'  => array(),
 	'exclude-constants'  => array(),

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -51,6 +51,14 @@ return array(
 	'exclude-constants'  => array(),
 
 	'expose-global-constants' => false,
-	'expose-global-classes'   => false,
+	// Composer's generated `ComposerAutoloaderInit<hash>` class lives in the
+	// global namespace and is referenced by string callback inside the
+	// composer-generated `autoload_real.php` (passed to spl_autoload_unregister).
+	// Scoper rewrites the class definition but not the string callback, which
+	// leaves a "class not found" fatal at boot. Exposing global classes makes
+	// scoper alias the prefixed name back to the original global one, so both
+	// names resolve. The hash makes this safe — no other plugin will define
+	// ComposerAutoloaderInit<this exact hash>.
+	'expose-global-classes'   => true,
 	'expose-global-functions' => false,
 );

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -2,16 +2,16 @@
 /**
  * php-scoper config for WP Document Revisions.
  *
- * Production composer dependencies are scoped under WP_Document_Revisions\Vendor
- * to avoid namespace collisions with other plugins shipping the same libraries
- * (a recurring problem for wordpress.org-distributed plugins).
+ * Intended to scope production composer dependencies under
+ * WP_Document_Revisions\Vendor to avoid namespace collisions with other
+ * plugins shipping the same libraries (a recurring problem for
+ * wordpress.org-distributed plugins).
  *
- * Phase 2 of issue #514: the pipeline exists, but no production dependencies
- * have been added yet, so this config currently scopes nothing. Phase 3 will
- * add smalot/pdfparser as the first scoped dependency.
- *
- * Run via `composer build:scope` after a production install
- * (`composer install --no-dev --no-progress`).
+ * Status: the pipeline (composer build:scope, vendor-bin/scoper, CI smoke
+ * job) is in place but not on the release path yet. smalot/pdfparser (the
+ * first production composer dep) currently ships unscoped from `vendor/`
+ * pending more work on scoper's Composer-autoload bootstrap edge cases. See
+ * issue #514 for context and `docs/CONTRIBUTING.md` for the dev workflow.
  *
  * @package WP_Document_Revisions
  */
@@ -33,32 +33,12 @@ return array(
 
 	'patchers' => array(),
 
-	'exclude-namespaces' => array(
-		// Leave Composer's own autoload machinery unscoped. If we let
-		// scoper rewrite it, vendor-prefixed/composer/autoload_real.php
-		// ends up referencing `WP_Document_Revisions\Vendor\Composer\
-		// Autoload\ClassLoader` but the ClassLoader.php file scoper
-		// produces is loaded by file path before that name resolves,
-		// and the result is "class not found" at boot. Excluding the
-		// `Composer\` namespace from scoping keeps the bootstrap
-		// internally consistent — the scoped deps still get prefixed
-		// via the classmap entries scoper rewrites in
-		// autoload_classmap.php.
-		'Composer\\',
-	),
+	'exclude-namespaces' => array(),
 	'exclude-classes'    => array(),
 	'exclude-functions'  => array(),
 	'exclude-constants'  => array(),
 
 	'expose-global-constants' => false,
-	// Composer's generated `ComposerAutoloaderInit<hash>` class lives in the
-	// global namespace and is referenced by string callback inside the
-	// composer-generated `autoload_real.php` (passed to spl_autoload_unregister).
-	// Scoper rewrites the class definition but not the string callback, which
-	// leaves a "class not found" fatal at boot. Exposing global classes makes
-	// scoper alias the prefixed name back to the original global one, so both
-	// names resolve. The hash makes this safe — no other plugin will define
-	// ComposerAutoloaderInit<this exact hash>.
-	'expose-global-classes'   => true,
+	'expose-global-classes'   => false,
 	'expose-global-functions' => false,
 );

--- a/vendor-bin/scoper/composer.json
+++ b/vendor-bin/scoper/composer.json
@@ -1,6 +1,6 @@
 {
-	"description": "Isolated composer manifest for php-scoper, installed by bamarni/composer-bin-plugin. See ../../scoper.inc.php and the build:scope script in the root composer.json.",
+	"description": "Isolated composer manifest for php-scoper. Installed with `composer install --working-dir=vendor-bin/scoper`; see ../../scoper.inc.php and the build:scope script in the root composer.json.",
 	"require": {
-		"humbug/php-scoper": "^0.18.18"
+		"humbug/php-scoper": "^0.27"
 	}
 }

--- a/vendor-bin/scoper/composer.json
+++ b/vendor-bin/scoper/composer.json
@@ -1,6 +1,6 @@
 {
 	"description": "Isolated composer manifest for php-scoper. Installed with `composer install --working-dir=vendor-bin/scoper`; see ../../scoper.inc.php and the build:scope script in the root composer.json.",
 	"require": {
-		"humbug/php-scoper": "^0.27"
+		"humbug/php-scoper": "^0.18.19"
 	}
 }

--- a/vendor-bin/scoper/composer.json
+++ b/vendor-bin/scoper/composer.json
@@ -1,6 +1,6 @@
 {
 	"description": "Isolated composer manifest for php-scoper. Installed with `composer install --working-dir=vendor-bin/scoper`; see ../../scoper.inc.php and the build:scope script in the root composer.json.",
 	"require": {
-		"humbug/php-scoper": "^0.18.19"
+		"humbug/php-scoper": "0.18.18"
 	}
 }

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -55,18 +55,19 @@ if ( ! defined( 'WPDR_VERSION' ) ) {
 	define( 'WPDR_VERSION', '4.0.7' );
 }
 
-// Composer autoloader for production / scoped dependencies.
+// Composer autoloader for production dependencies.
 //
-// Release builds ship `vendor-prefixed/` (produced by `composer build:scope`).
-// Dev environments that have only run `composer install` keep the unprefixed
-// `vendor/` tree. The shim below picks whichever is present, and then registers
-// an autoloader that maps unscoped `Smalot\PdfParser\*` (and any future scoped
-// vendor namespace) onto the prefixed `WP_Document_Revisions\Vendor\*` names
-// the plugin uses internally, so the same plugin source works in both modes.
+// Today smalot/pdfparser ships unscoped from `vendor/` — both dev and
+// release. The `vendor-prefixed/` branches below stay as defensive code so
+// that the future scoper-on-the-release-path switch (when the Composer-
+// autoload bootstrap edge cases are worked out — see scoper.inc.php) needs
+// no further changes here. php-scoper writes `scoper-autoload.php` from
+// 0.19 onward and a plain `autoload.php` in 0.18, hence the two paths.
 //
-// php-scoper writes `scoper-autoload.php` from 0.19 onward; 0.18 and earlier
-// only wrote a scoped `autoload.php`. Check both so version bumps don't break
-// the bootstrap.
+// In every shipping configuration today the `vendor/autoload.php` branch
+// is the one that runs; the spl_autoload_register shim then registers an
+// alias so plugin code referencing `WP_Document_Revisions\Vendor\*` keeps
+// working if a downstream user opts into scoping locally.
 if ( file_exists( __DIR__ . '/vendor-prefixed/scoper-autoload.php' ) ) {
 	require_once __DIR__ . '/vendor-prefixed/scoper-autoload.php';
 } elseif ( file_exists( __DIR__ . '/vendor-prefixed/autoload.php' ) ) {

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -55,6 +55,33 @@ if ( ! defined( 'WPDR_VERSION' ) ) {
 	define( 'WPDR_VERSION', '4.0.7' );
 }
 
+// Composer autoloader for production / scoped dependencies.
+//
+// Release builds ship `vendor-prefixed/` (produced by `composer build:scope`).
+// Dev environments that have only run `composer install` keep the unprefixed
+// `vendor/` tree. The shim below picks whichever is present, and then registers
+// an autoloader that maps unscoped `Smalot\PdfParser\*` (and any future scoped
+// vendor namespace) onto the prefixed `WP_Document_Revisions\Vendor\*` names
+// the plugin uses internally, so the same plugin source works in both modes.
+if ( file_exists( __DIR__ . '/vendor-prefixed/scoper-autoload.php' ) ) {
+	require_once __DIR__ . '/vendor-prefixed/scoper-autoload.php';
+} elseif ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+
+	spl_autoload_register(
+		static function ( $class ) {
+			$prefix = 'WP_Document_Revisions\\Vendor\\';
+			if ( 0 !== strpos( $class, $prefix ) ) {
+				return;
+			}
+			$unscoped = substr( $class, strlen( $prefix ) );
+			if ( class_exists( $unscoped ) || interface_exists( $unscoped ) || trait_exists( $unscoped ) ) {
+				class_alias( $unscoped, $class );
+			}
+		}
+	);
+}
+
 require_once __DIR__ . '/includes/trait-wp-document-revisions-rewrites.php';
 require_once __DIR__ . '/includes/trait-wp-document-revisions-file-handler.php';
 require_once __DIR__ . '/includes/trait-wp-document-revisions-revisions.php';

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -69,14 +69,14 @@ if ( file_exists( __DIR__ . '/vendor-prefixed/scoper-autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
 
 	spl_autoload_register(
-		static function ( $class ) {
+		static function ( $class_name ) {
 			$prefix = 'WP_Document_Revisions\\Vendor\\';
-			if ( 0 !== strpos( $class, $prefix ) ) {
+			if ( 0 !== strpos( $class_name, $prefix ) ) {
 				return;
 			}
-			$unscoped = substr( $class, strlen( $prefix ) );
+			$unscoped = substr( $class_name, strlen( $prefix ) );
 			if ( class_exists( $unscoped ) || interface_exists( $unscoped ) || trait_exists( $unscoped ) ) {
-				class_alias( $unscoped, $class );
+				class_alias( $unscoped, $class_name );
 			}
 		}
 	);

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -63,8 +63,8 @@ if ( ! defined( 'WPDR_VERSION' ) ) {
 // an autoloader that maps unscoped `Smalot\PdfParser\*` (and any future scoped
 // vendor namespace) onto the prefixed `WP_Document_Revisions\Vendor\*` names
 // the plugin uses internally, so the same plugin source works in both modes.
-if ( file_exists( __DIR__ . '/vendor-prefixed/scoper-autoload.php' ) ) {
-	require_once __DIR__ . '/vendor-prefixed/scoper-autoload.php';
+if ( file_exists( __DIR__ . '/vendor-prefixed/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor-prefixed/autoload.php';
 } elseif ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
 

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -63,7 +63,13 @@ if ( ! defined( 'WPDR_VERSION' ) ) {
 // an autoloader that maps unscoped `Smalot\PdfParser\*` (and any future scoped
 // vendor namespace) onto the prefixed `WP_Document_Revisions\Vendor\*` names
 // the plugin uses internally, so the same plugin source works in both modes.
-if ( file_exists( __DIR__ . '/vendor-prefixed/autoload.php' ) ) {
+//
+// php-scoper writes `scoper-autoload.php` from 0.19 onward; 0.18 and earlier
+// only wrote a scoped `autoload.php`. Check both so version bumps don't break
+// the bootstrap.
+if ( file_exists( __DIR__ . '/vendor-prefixed/scoper-autoload.php' ) ) {
+	require_once __DIR__ . '/vendor-prefixed/scoper-autoload.php';
+} elseif ( file_exists( __DIR__ . '/vendor-prefixed/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor-prefixed/autoload.php';
 } elseif ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary

Phase 3a of issue #514. **Infrastructure only** — no extractor class, no auto-registration, no extractor tests. That all lands in Phase 3b on top of this PR.

### What lands

- **`smalot/pdfparser ^2.10`** in `composer.json`'s `require`, plus a matching `"php": ">=7.4"` constraint mirroring the plugin's `Requires PHP` header. Smalot is installed via `composer install --no-dev` in the deploy workflow and ships **unscoped** from `vendor/` to wordpress.org.
- **Conditional autoload + `class_alias` shim** in `wp-document-revisions.php`. Boots from `vendor-prefixed/scoper-autoload.php` (php-scoper 0.19+), `vendor-prefixed/autoload.php` (older scoper), or `vendor/autoload.php` (today's path), and registers a `class_alias` shim so any plugin code referencing `WP_Document_Revisions\Vendor\*` still resolves. Keeps the vendor-prefixed branches as defensive code so the eventual scoping switch needs no further plugin-bootstrap changes.
- **`deploy.yml`** now runs `composer install --no-dev` before the 10up plugin-deploy action so the release ships production deps in `vendor/`.
- **`.distignore`** intentionally does not exclude `vendor/` — the unscoped production tree ships.

### Scoping is deferred (work-in-progress, not on the release path)

The original Phase 3a plan was to scope smalot under `WP_Document_Revisions\Vendor\` via the Phase 2 pipeline. After five CI rounds chasing php-scoper edge cases around Composer's own autoload bootstrap (`ClassLoader`, `ComposerAutoloaderInit<hash>`, classmap consistency), the flag-twiddling approach was not converging. Per direction, this PR ships smalot unscoped and leaves the scoper infrastructure (`composer build:scope`, `vendor-bin/scoper/`, `scoper.inc.php`, the `scoper-pipeline` CI smoke) in place but **off the release path** for a future revisit.

`scoper.inc.php` is back to Phase 2's empty defaults. CONTRIBUTING.md describes today's plain `composer install` workflow and calls out the scoper pipeline as work-in-progress.

### Intentionally not in scope

- The `WP_Document_Revisions_PDF_Text_Extractor` class — phase 3b.
- Auto-registration via the `wpdr_text_extractors` filter — phase 3b.
- Mock-parser unit tests + real-PDF integration tests — phase 3b.
- Promoting the scoper pipeline onto the release path — deferred until the Composer-autoload bootstrap can be debugged properly.

## Test plan

- [ ] CI `code-quality` passes (composer install + smalot resolves + phpcs + phpstan + audit)
- [ ] CI `scoper-pipeline` smoke passes (composer install --no-dev + build:scope + vendor-prefixed/ produced)
- [ ] CI phpunit matrices pass (plugin loads via vendor/autoload.php + alias shim)
- [ ] composer audit does not flag a critical advisory on smalot

Closes part of #514 (phase 3a of 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)