### PR TITLE
Add PDF text extractor + auto-registration (#514, phase 3b)

### DIFF
--- a/includes/class-wp-document-revisions-pdf-text-extractor.php
+++ b/includes/class-wp-document-revisions-pdf-text-extractor.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * PDF text extractor backed by smalot/pdfparser.
+ *
+ * Handles `application/pdf`. Encrypted, malformed, or otherwise unreadable
+ * PDFs return an empty string rather than throwing, so a single bad file
+ * cannot interrupt a check-in. Scanned PDFs (no embedded text layer) also
+ * return empty — see the OCR follow-up in issue #514 for that path.
+ *
+ * @since 4.1.0
+ * @package WP_Document_Revisions
+ */
+
+// direct file access protection.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * PDF text extractor.
+ */
+class WP_Document_Revisions_PDF_Text_Extractor implements WP_Document_Revisions_Text_Extractor {
+
+	/**
+	 * Whether this extractor can handle the given MIME type.
+	 *
+	 * @param string $mime_type the MIME type to check.
+	 * @return bool true for application/pdf, false otherwise.
+	 */
+	public function supports( string $mime_type ): bool {
+		return 'application/pdf' === $mime_type;
+	}
+
+	/**
+	 * Extract plain text from a PDF file.
+	 *
+	 * @param string $file_path absolute path to the PDF on disk.
+	 * @param string $mime_type the MIME type (unused; supports() gates this).
+	 * @return string extracted text, or empty string if parsing fails or the
+	 *                PDF contains no embedded text layer.
+	 */
+	public function extract( string $file_path, string $mime_type ): string {
+		unset( $mime_type );
+
+		try {
+			$parser = new \Smalot\PdfParser\Parser();
+			$pdf    = $parser->parseFile( $file_path );
+
+			return (string) $pdf->getText();
+		} catch ( \Throwable $e ) {
+			// Encrypted, malformed, or unsupported PDF (or smalot itself
+			// hit an internal error). Returning empty matches the interface
+			// contract for "nothing could be extracted" and avoids logging
+			// noise on sites that upload many such files. Per-file failure
+			// tracking lands with the caching/opt-out phases.
+			return '';
+		}
+	}
+}

--- a/tests/class-test-wp-document-revisions-pdf-text-extractor.php
+++ b/tests/class-test-wp-document-revisions-pdf-text-extractor.php
@@ -15,7 +15,7 @@
 class Test_WP_Document_Revisions_PDF_Text_Extractor extends Test_Common_WPDR {
 
 	/**
-	 * supports() returns true for application/pdf and false for everything else.
+	 * Supports returns true for application/pdf and false for everything else.
 	 */
 	public function test_supports_only_application_pdf() {
 		$extractor = new WP_Document_Revisions_PDF_Text_Extractor();
@@ -28,7 +28,7 @@ class Test_WP_Document_Revisions_PDF_Text_Extractor extends Test_Common_WPDR {
 	}
 
 	/**
-	 * extract() returns non-empty alphabetic text from the bundled test PDF.
+	 * Returns non-empty alphabetic text when run against the bundled PDF.
 	 *
 	 * Deliberately not asserting the literal content — only that smalot ran
 	 * and produced a sensible string. Tightening the assertion couples the
@@ -45,9 +45,9 @@ class Test_WP_Document_Revisions_PDF_Text_Extractor extends Test_Common_WPDR {
 	}
 
 	/**
-	 * extract() returns an empty string for a missing file rather than
-	 * throwing — defensive even though the registry already short-circuits
-	 * unreadable paths before calling into the extractor.
+	 * Returns an empty string for a missing file rather than throwing —
+	 * defensive even though the registry already short-circuits unreadable
+	 * paths before calling into the extractor.
 	 */
 	public function test_extract_returns_empty_for_missing_file() {
 		$extractor = new WP_Document_Revisions_PDF_Text_Extractor();
@@ -56,8 +56,8 @@ class Test_WP_Document_Revisions_PDF_Text_Extractor extends Test_Common_WPDR {
 	}
 
 	/**
-	 * extract() returns an empty string when handed a plain text file
-	 * masquerading as a PDF — smalot throws, the extractor catches.
+	 * Returns an empty string when handed a plain text file masquerading as
+	 * a PDF — smalot throws, the extractor catches.
 	 */
 	public function test_extract_returns_empty_for_non_pdf_content() {
 		$extractor = new WP_Document_Revisions_PDF_Text_Extractor();
@@ -94,8 +94,8 @@ class Test_WP_Document_Revisions_PDF_Text_Extractor extends Test_Common_WPDR {
 	}
 
 	/**
-	 * wpdr_extract_text() — the public template function — produces text
-	 * end-to-end when called against a PDF attachment.
+	 * End-to-end: the public wpdr_extract_text() template function produces
+	 * text when called against a PDF attachment.
 	 */
 	public function test_wpdr_extract_text_runs_pdf_extractor_against_attachment() {
 		$doc_id = self::factory()->post->create(

--- a/tests/class-test-wp-document-revisions-pdf-text-extractor.php
+++ b/tests/class-test-wp-document-revisions-pdf-text-extractor.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Tests for the built-in PDF text extractor.
+ *
+ * Phase 3b of issue #514: exercises WP_Document_Revisions_PDF_Text_Extractor
+ * against the existing Document1.pdf fixture, plus the auto-registration
+ * hooked from wp-document-revisions.php.
+ *
+ * @package WP_Document_Revisions
+ */
+
+/**
+ * Tests for WP_Document_Revisions_PDF_Text_Extractor and its auto-registration.
+ */
+class Test_WP_Document_Revisions_PDF_Text_Extractor extends Test_Common_WPDR {
+
+	/**
+	 * supports() returns true for application/pdf and false for everything else.
+	 */
+	public function test_supports_only_application_pdf() {
+		$extractor = new WP_Document_Revisions_PDF_Text_Extractor();
+
+		self::assertTrue( $extractor->supports( 'application/pdf' ) );
+		self::assertFalse( $extractor->supports( 'text/plain' ) );
+		self::assertFalse( $extractor->supports( 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ) );
+		self::assertFalse( $extractor->supports( '' ) );
+		self::assertFalse( $extractor->supports( 'application/pdf; charset=binary' ) );
+	}
+
+	/**
+	 * extract() returns non-empty alphabetic text from the bundled test PDF.
+	 *
+	 * Deliberately not asserting the literal content — only that smalot ran
+	 * and produced a sensible string. Tightening the assertion couples the
+	 * test to the fixture's words.
+	 */
+	public function test_extract_returns_text_from_real_pdf() {
+		$extractor = new WP_Document_Revisions_PDF_Text_Extractor();
+
+		$text = $extractor->extract( self::$pdf_file, 'application/pdf' );
+
+		self::assertIsString( $text );
+		self::assertNotSame( '', trim( $text ), 'Expected non-whitespace text from Document1.pdf' );
+		self::assertMatchesRegularExpression( '/[A-Za-z]/', $text, 'Expected at least one alphabetic character' );
+	}
+
+	/**
+	 * extract() returns an empty string for a missing file rather than
+	 * throwing — defensive even though the registry already short-circuits
+	 * unreadable paths before calling into the extractor.
+	 */
+	public function test_extract_returns_empty_for_missing_file() {
+		$extractor = new WP_Document_Revisions_PDF_Text_Extractor();
+
+		self::assertSame( '', $extractor->extract( '/no/such/file.pdf', 'application/pdf' ) );
+	}
+
+	/**
+	 * extract() returns an empty string when handed a plain text file
+	 * masquerading as a PDF — smalot throws, the extractor catches.
+	 */
+	public function test_extract_returns_empty_for_non_pdf_content() {
+		$extractor = new WP_Document_Revisions_PDF_Text_Extractor();
+
+		self::assertSame( '', $extractor->extract( self::$test_file, 'application/pdf' ) );
+	}
+
+	/**
+	 * The plugin bootstrap auto-registers the PDF extractor via the
+	 * wpdr_text_extractors filter.
+	 */
+	public function test_pdf_extractor_is_registered_by_default() {
+		$extractors = WP_Document_Revisions_Text_Extractor_Registry::get_extractors();
+
+		$has_pdf = false;
+		foreach ( $extractors as $extractor ) {
+			if ( $extractor instanceof WP_Document_Revisions_PDF_Text_Extractor ) {
+				$has_pdf = true;
+				break;
+			}
+		}
+
+		self::assertTrue( $has_pdf, 'Expected WP_Document_Revisions_PDF_Text_Extractor in the default registry' );
+	}
+
+	/**
+	 * The registry resolves application/pdf to the built-in extractor when
+	 * no third party has overridden it.
+	 */
+	public function test_registry_resolves_pdf_to_built_in_extractor() {
+		$extractor = WP_Document_Revisions_Text_Extractor_Registry::find_for( 'application/pdf' );
+
+		self::assertInstanceOf( WP_Document_Revisions_PDF_Text_Extractor::class, $extractor );
+	}
+
+	/**
+	 * wpdr_extract_text() — the public template function — produces text
+	 * end-to-end when called against a PDF attachment.
+	 */
+	public function test_wpdr_extract_text_runs_pdf_extractor_against_attachment() {
+		$doc_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'PDF Extractor Document',
+				'post_type'   => 'document',
+				'post_status' => 'publish',
+			)
+		);
+		self::add_document_attachment( self::factory(), $doc_id, self::$pdf_file );
+
+		global $wpdr;
+		$revision  = $wpdr->get_latest_revision( $doc_id );
+		$attach_id = (int) $revision->post_content;
+
+		$text = wpdr_extract_text( $attach_id );
+
+		self::assertIsString( $text );
+		self::assertNotSame( '', trim( $text ) );
+		self::assertMatchesRegularExpression( '/[A-Za-z]/', $text );
+	}
+}

--- a/tests/class-test-wp-document-revisions-text-extractor.php
+++ b/tests/class-test-wp-document-revisions-text-extractor.php
@@ -23,6 +23,17 @@ class Test_WP_Document_Revisions_Text_Extractor extends Test_Common_WPDR {
 	}
 
 	/**
+	 * Start each test with no extractors registered. The plugin bootstrap
+	 * auto-registers WP_Document_Revisions_PDF_Text_Extractor via the
+	 * wpdr_text_extractors filter; these tests target the dispatcher itself,
+	 * so clear the slate to keep their setup explicit.
+	 */
+	public function set_up() {
+		parent::set_up();
+		remove_all_filters( 'wpdr_text_extractors' );
+	}
+
+	/**
 	 * Clear any filters registered during a test so they don't leak across tests.
 	 */
 	public function tear_down() {

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -96,7 +96,20 @@ require_once __DIR__ . '/includes/trait-wp-document-revisions-query.php';
 require_once __DIR__ . '/includes/interface-wp-document-revisions-text-extractor.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-extraction-exception.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-extractor-registry.php';
+require_once __DIR__ . '/includes/class-wp-document-revisions-pdf-text-extractor.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions.php';
+
+// Register the built-in PDF text extractor. Lazy construction inside the
+// filter callback avoids paying the parser allocation cost on requests that
+// never extract anything. Third parties can prepend their own extractors at
+// a higher priority to override this one.
+add_filter(
+	'wpdr_text_extractors',
+	static function ( array $extractors ): array {
+		$extractors[] = new WP_Document_Revisions_PDF_Text_Extractor();
+		return $extractors;
+	}
+);
 
 // $wpdr is a global reference to the class.
 global $wpdr;


### PR DESCRIPTION
## Summary

Phase 3b of issue #514. Builds on Phase 3a's `smalot/pdfparser` dependency and the Phase 1 text-extractor interface to ship the first concrete extractor.

### What lands

- **`WP_Document_Revisions_PDF_Text_Extractor`** (`includes/class-wp-document-revisions-pdf-text-extractor.php`) — implements `supports('application/pdf')` and an `extract()` that calls `Smalot\PdfParser\Parser::parseFile()` inside `catch (\Throwable)` so encrypted, malformed, or scanned (no-text) PDFs return `''` rather than fatal the revision check-in. No per-file `error_log` noise in this phase; per-file failure tracking lands with the caching / opt-out work.
- **Auto-registration** via `add_filter('wpdr_text_extractors', ...)` in `wp-document-revisions.php` with a lazy callback, so the parser is constructed only when extractors are iterated. Third parties can prepend to override at a higher filter priority.
- **Tests** (`tests/class-test-wp-document-revisions-pdf-text-extractor.php`) covering:
  - `supports()` only matches `application/pdf` (rejects `text/plain`, DOCX MIME, empty, charset-suffixed pdf)
  - `extract()` on the existing `tests/documents/Document1.pdf` fixture returns non-empty alphabetic text (no fixture-content coupling)
  - `extract()` returns empty on a missing file
  - `extract()` returns empty when handed plain text masquerading as a PDF (smalot throws, extractor catches)
  - The default registry includes the built-in extractor
  - `find_for('application/pdf')` resolves to the built-in
  - `wpdr_extract_text()` end-to-end against a PDF attachment

### Intentionally not in scope

- Caching extracted text as post meta + SHA-256 invalidation — phase 6
- Async scheduling via `wp_schedule_single_event` — phase 7
- Per-document and global opt-out — phase 8
- WP-CLI backfill — phase 9
- Diff utility and AI revision summaries — phases 10–12
- Per-file failure tracking (`error_log` on parse failures) — moves with phase 6's `_wpdr_extraction_failed` flag

## Test plan

- [ ] CI `code-quality` (phpcs, phpstan, audit) passes
- [ ] CI phpunit matrices pass; `Test_WP_Document_Revisions_PDF_Text_Extractor` tests all green
- [ ] PDF extraction works against the bundled `Document1.pdf` fixture
- [ ] No CI extension changes needed (smalot installs cleanly per phase 3a; mbstring is in the default setup-php install)

Closes part of #514 (phase 3b of 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)