### PR TITLE
Add DOCX/ODT text extractor + auto-registration (#514, phase 4)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
 	],
 	"require": {
 		"php": ">=7.4",
-		"smalot/pdfparser": "^2.10"
+		"smalot/pdfparser": "^2.10",
+		"phpoffice/phpword": "^1.3"
 	},
 	"require-dev": {
 		"phpcsstandards/phpcsutils": "^1.1",

--- a/includes/class-wp-document-revisions-docx-text-extractor.php
+++ b/includes/class-wp-document-revisions-docx-text-extractor.php
@@ -190,7 +190,12 @@ class WP_Document_Revisions_DOCX_Text_Extractor implements WP_Document_Revisions
 			foreach ( $row->getCells() as $cell ) {
 				$cell_texts[] = $this->extract_from_container( $cell );
 			}
-			$cell_texts = array_filter( $cell_texts, 'strlen' );
+			$cell_texts = array_filter(
+				$cell_texts,
+				static function ( string $cell ): bool {
+					return '' !== $cell;
+				}
+			);
 			if ( ! empty( $cell_texts ) ) {
 				$rows[] = implode( "\t", $cell_texts );
 			}
@@ -199,12 +204,22 @@ class WP_Document_Revisions_DOCX_Text_Extractor implements WP_Document_Revisions
 	}
 
 	/**
-	 * Drop empty strings and join the rest with newlines.
+	 * Drop empty strings and join the rest with newlines. Closure rather
+	 * than 'strlen' so phpstan sees a callable returning bool (strlen
+	 * returns int, even though PHP coerces it to a truthy/falsy bool).
 	 *
 	 * @param string[] $parts text fragments to concatenate.
 	 * @return string non-empty fragments joined by newline.
 	 */
 	private function join_parts( array $parts ): string {
-		return implode( "\n", array_filter( $parts, 'strlen' ) );
+		return implode(
+			"\n",
+			array_filter(
+				$parts,
+				static function ( string $part ): bool {
+					return '' !== $part;
+				}
+			)
+		);
 	}
 }

--- a/includes/class-wp-document-revisions-docx-text-extractor.php
+++ b/includes/class-wp-document-revisions-docx-text-extractor.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * DOCX (and ODT) text extractor backed by phpoffice/phpword.
+ *
+ * Handles `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
+ * (DOCX) and, as a bonus since PHPWord reads it too,
+ * `application/vnd.oasis.opendocument.text` (ODT). Legacy `application/msword`
+ * (DOC) is intentionally NOT supported here — it belongs to a separate
+ * shell-out-to-LibreOffice extractor (phase 5 of issue #514).
+ *
+ * Encrypted, malformed, or otherwise unreadable files return an empty
+ * string rather than throwing, so a single bad file cannot interrupt a
+ * check-in.
+ *
+ * @since 4.1.0
+ * @package WP_Document_Revisions
+ */
+
+// direct file access protection.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * DOCX/ODT text extractor.
+ */
+class WP_Document_Revisions_DOCX_Text_Extractor implements WP_Document_Revisions_Text_Extractor {
+
+	/**
+	 * MIME types this extractor accepts.
+	 *
+	 * @var string[]
+	 */
+	private const SUPPORTED_MIME_TYPES = array(
+		'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+		'application/vnd.oasis.opendocument.text',
+	);
+
+	/**
+	 * Whether this extractor can handle the given MIME type.
+	 *
+	 * @param string $mime_type the MIME type to check.
+	 * @return bool true for DOCX or ODT, false otherwise.
+	 */
+	public function supports( string $mime_type ): bool {
+		return in_array( $mime_type, self::SUPPORTED_MIME_TYPES, true );
+	}
+
+	/**
+	 * Extract plain text from a DOCX or ODT file.
+	 *
+	 * @param string $file_path absolute path to the file on disk.
+	 * @param string $mime_type the MIME type, used to pick the PHPWord reader.
+	 * @return string extracted text, or empty string on any parse failure.
+	 */
+	public function extract( string $file_path, string $mime_type ): string {
+		try {
+			$reader  = $this->reader_for( $mime_type );
+			$phpword = \PhpOffice\PhpWord\IOFactory::load( $file_path, $reader );
+
+			return $this->extract_from_phpword( $phpword );
+		} catch ( \Throwable $e ) {
+			// Malformed, encrypted, or otherwise unreadable. The dispatcher
+			// receives empty rather than an exception so one bad file does
+			// not break the caller. Per-file failure tracking lands with
+			// the caching / opt-out phases.
+			return '';
+		}
+	}
+
+	/**
+	 * Map a MIME type to the PHPWord reader name.
+	 *
+	 * @param string $mime_type the file's MIME type.
+	 * @return string PHPWord reader identifier.
+	 */
+	private function reader_for( string $mime_type ): string {
+		if ( 'application/vnd.oasis.opendocument.text' === $mime_type ) {
+			return 'ODText';
+		}
+		return 'Word2007';
+	}
+
+	/**
+	 * Walk every section in a parsed PhpWord document and join the text.
+	 *
+	 * @param \PhpOffice\PhpWord\PhpWord $phpword parsed document.
+	 * @return string concatenated text from sections, headers, and footers.
+	 */
+	private function extract_from_phpword( \PhpOffice\PhpWord\PhpWord $phpword ): string {
+		$parts = array();
+		foreach ( $phpword->getSections() as $section ) {
+			$parts[] = $this->extract_from_section( $section );
+		}
+		return $this->join_parts( $parts );
+	}
+
+	/**
+	 * Extract text from a single section, including its headers and footers.
+	 *
+	 * @param \PhpOffice\PhpWord\Element\Section $section section to walk.
+	 * @return string concatenated text.
+	 */
+	private function extract_from_section( \PhpOffice\PhpWord\Element\Section $section ): string {
+		$parts = array();
+
+		foreach ( $section->getHeaders() as $header ) {
+			$parts[] = $this->extract_from_container( $header );
+		}
+
+		foreach ( $section->getElements() as $element ) {
+			$parts[] = $this->extract_from_element( $element );
+		}
+
+		foreach ( $section->getFooters() as $footer ) {
+			$parts[] = $this->extract_from_container( $footer );
+		}
+
+		return $this->join_parts( $parts );
+	}
+
+	/**
+	 * Walk a container (Header, Footer, Cell, or any element exposing
+	 * getElements()) and concatenate its child text.
+	 *
+	 * @param object $container element whose children should be walked.
+	 * @return string concatenated text.
+	 */
+	private function extract_from_container( $container ): string {
+		if ( ! method_exists( $container, 'getElements' ) ) {
+			return '';
+		}
+
+		$parts = array();
+		foreach ( $container->getElements() as $element ) {
+			$parts[] = $this->extract_from_element( $element );
+		}
+		return $this->join_parts( $parts );
+	}
+
+	/**
+	 * Dispatch on element type. Text and TextRun produce strings; tables
+	 * walk their rows and cells; list items pull text from their inner text
+	 * object; unknown containers fall back to a generic getElements() walk.
+	 *
+	 * @param object $element PHPWord element.
+	 * @return string text contributed by this element.
+	 */
+	private function extract_from_element( $element ): string {
+		if ( $element instanceof \PhpOffice\PhpWord\Element\Text ) {
+			return (string) $element->getText();
+		}
+
+		if ( $element instanceof \PhpOffice\PhpWord\Element\TextRun ) {
+			return $this->extract_from_container( $element );
+		}
+
+		if ( $element instanceof \PhpOffice\PhpWord\Element\Table ) {
+			return $this->extract_from_table( $element );
+		}
+
+		if ( $element instanceof \PhpOffice\PhpWord\Element\ListItem ) {
+			$text_object = $element->getTextObject();
+			if ( $text_object instanceof \PhpOffice\PhpWord\Element\Text ) {
+				return (string) $text_object->getText();
+			}
+			return '';
+		}
+
+		// Unknown container — try a generic walk before giving up.
+		if ( method_exists( $element, 'getElements' ) ) {
+			return $this->extract_from_container( $element );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Walk a table's rows and cells. Cells in a row are joined with tabs so
+	 * downstream consumers can still tell columns apart; rows are joined
+	 * with newlines.
+	 *
+	 * @param \PhpOffice\PhpWord\Element\Table $table table element.
+	 * @return string flattened table text.
+	 */
+	private function extract_from_table( \PhpOffice\PhpWord\Element\Table $table ): string {
+		$rows = array();
+		foreach ( $table->getRows() as $row ) {
+			$cell_texts = array();
+			foreach ( $row->getCells() as $cell ) {
+				$cell_texts[] = $this->extract_from_container( $cell );
+			}
+			$cell_texts = array_filter( $cell_texts, 'strlen' );
+			if ( ! empty( $cell_texts ) ) {
+				$rows[] = implode( "\t", $cell_texts );
+			}
+		}
+		return $this->join_parts( $rows );
+	}
+
+	/**
+	 * Drop empty strings and join the rest with newlines.
+	 *
+	 * @param string[] $parts text fragments to concatenate.
+	 * @return string non-empty fragments joined by newline.
+	 */
+	private function join_parts( array $parts ): string {
+		return implode( "\n", array_filter( $parts, 'strlen' ) );
+	}
+}

--- a/tests/class-test-wp-document-revisions-docx-text-extractor.php
+++ b/tests/class-test-wp-document-revisions-docx-text-extractor.php
@@ -298,8 +298,28 @@ class Test_WP_Document_Revisions_DOCX_Text_Extractor extends Test_Common_WPDR {
 		$revision  = $wpdr->get_latest_revision( $doc_id );
 		$attach_id = (int) $revision->post_content;
 
+		// Diagnostic state in case the assertion below fails: print what
+		// wpdr_extract_text() actually sees so we don't have to guess at
+		// the wp_upload_dir filter / MIME / path interaction.
+		$attached_path = get_attached_file( $attach_id );
+		$attached_mime = get_post_mime_type( $attach_id );
+		$direct_text   = ( new WP_Document_Revisions_DOCX_Text_Extractor() )->extract(
+			(string) $attached_path,
+			(string) $attached_mime
+		);
+
 		$text = wpdr_extract_text( $attach_id );
 
-		self::assertStringContainsString( 'Integration test content.', $text );
+		$diagnostic = sprintf(
+			"path=%s exists=%s readable=%s mime=%s direct_extract_len=%d wpdr_extract_len=%d",
+			$attached_path,
+			( $attached_path && file_exists( $attached_path ) ) ? 'yes' : 'no',
+			( $attached_path && is_readable( $attached_path ) ) ? 'yes' : 'no',
+			$attached_mime,
+			strlen( $direct_text ),
+			strlen( $text )
+		);
+
+		self::assertStringContainsString( 'Integration test content.', $text, $diagnostic );
 	}
 }

--- a/tests/class-test-wp-document-revisions-docx-text-extractor.php
+++ b/tests/class-test-wp-document-revisions-docx-text-extractor.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * Tests for the built-in DOCX/ODT text extractor.
+ *
+ * Phase 4 of issue #514. Fixtures are generated programmatically with
+ * PHPWord per the decision in the PR thread — this means the tests cover
+ * the PHPWord writer + the extractor as a pair, not the extractor against
+ * real-world Word/LibreOffice output. A follow-up should drop checked-in
+ * Word/LibreOffice fixtures into tests/documents/ and exercise the
+ * extractor against those.
+ *
+ * @package WP_Document_Revisions
+ */
+
+/**
+ * Tests for WP_Document_Revisions_DOCX_Text_Extractor and its auto-registration.
+ */
+class Test_WP_Document_Revisions_DOCX_Text_Extractor extends Test_Common_WPDR {
+
+	/**
+	 * DOCX MIME type constant for readability.
+	 *
+	 * @var string
+	 */
+	const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+	/**
+	 * ODT MIME type constant.
+	 *
+	 * @var string
+	 */
+	const ODT_MIME = 'application/vnd.oasis.opendocument.text';
+
+	/**
+	 * Temp files created by individual tests; cleaned in tear_down.
+	 *
+	 * @var string[]
+	 */
+	private $temp_files = array();
+
+	/**
+	 * Delete any temp DOCX/ODT files written during the test.
+	 */
+	public function tear_down() {
+		foreach ( $this->temp_files as $path ) {
+			if ( file_exists( $path ) ) {
+				unlink( $path );
+			}
+		}
+		$this->temp_files = array();
+		parent::tear_down();
+	}
+
+	/**
+	 * Build a PhpWord document with caller-supplied content and persist it
+	 * to a temp file via the requested writer.
+	 *
+	 * @param callable $builder receives a PhpWord instance, populates it.
+	 * @param string   $writer  PHPWord writer name ('Word2007' or 'ODText').
+	 * @param string   $ext     file extension to use for the temp file.
+	 * @return string path to the generated file.
+	 */
+	private function build_document( callable $builder, string $writer = 'Word2007', string $ext = '.docx' ): string {
+		$phpword = new \PhpOffice\PhpWord\PhpWord();
+		$builder( $phpword );
+
+		$path = tempnam( sys_get_temp_dir(), 'wpdr_test_' );
+		// tempnam returns a path with no extension; rename so PHPWord picks
+		// the right reader hint on load and the file name reads naturally
+		// in any debugging output.
+		$with_ext = $path . $ext;
+		rename( $path, $with_ext );
+
+		$writer_obj = \PhpOffice\PhpWord\IOFactory::createWriter( $phpword, $writer );
+		$writer_obj->save( $with_ext );
+
+		$this->temp_files[] = $with_ext;
+		return $with_ext;
+	}
+
+	/**
+	 * Supports returns true for DOCX and ODT, false for everything else
+	 * (including legacy application/msword which belongs to phase 5).
+	 */
+	public function test_supports_only_docx_and_odt() {
+		$extractor = new WP_Document_Revisions_DOCX_Text_Extractor();
+
+		self::assertTrue( $extractor->supports( self::DOCX_MIME ) );
+		self::assertTrue( $extractor->supports( self::ODT_MIME ) );
+
+		self::assertFalse( $extractor->supports( 'application/msword' ) );
+		self::assertFalse( $extractor->supports( 'application/pdf' ) );
+		self::assertFalse( $extractor->supports( 'text/plain' ) );
+		self::assertFalse( $extractor->supports( '' ) );
+	}
+
+	/**
+	 * Returns plain paragraph text from a basic DOCX.
+	 */
+	public function test_extract_returns_paragraph_text() {
+		$path = $this->build_document(
+			static function ( \PhpOffice\PhpWord\PhpWord $phpword ): void {
+				$section = $phpword->addSection();
+				$section->addText( 'Hello DOCX world.' );
+				$section->addText( 'Second paragraph.' );
+			}
+		);
+
+		$extractor = new WP_Document_Revisions_DOCX_Text_Extractor();
+		$text      = $extractor->extract( $path, self::DOCX_MIME );
+
+		self::assertStringContainsString( 'Hello DOCX world.', $text );
+		self::assertStringContainsString( 'Second paragraph.', $text );
+	}
+
+	/**
+	 * Walks tables and pulls cell content from every row.
+	 */
+	public function test_extract_returns_table_cell_text() {
+		$path = $this->build_document(
+			static function ( \PhpOffice\PhpWord\PhpWord $phpword ): void {
+				$section = $phpword->addSection();
+				$table   = $section->addTable();
+
+				$row1 = $table->addRow();
+				$row1->addCell()->addText( 'Header A' );
+				$row1->addCell()->addText( 'Header B' );
+
+				$row2 = $table->addRow();
+				$row2->addCell()->addText( 'Cell 1A' );
+				$row2->addCell()->addText( 'Cell 1B' );
+			}
+		);
+
+		$extractor = new WP_Document_Revisions_DOCX_Text_Extractor();
+		$text      = $extractor->extract( $path, self::DOCX_MIME );
+
+		self::assertStringContainsString( 'Header A', $text );
+		self::assertStringContainsString( 'Header B', $text );
+		self::assertStringContainsString( 'Cell 1A', $text );
+		self::assertStringContainsString( 'Cell 1B', $text );
+	}
+
+	/**
+	 * Pulls text from headers and footers in addition to the section body.
+	 */
+	public function test_extract_returns_header_and_footer_text() {
+		$path = $this->build_document(
+			static function ( \PhpOffice\PhpWord\PhpWord $phpword ): void {
+				$section = $phpword->addSection();
+				$section->addHeader()->addText( 'Document header line' );
+				$section->addText( 'Body paragraph' );
+				$section->addFooter()->addText( 'Document footer line' );
+			}
+		);
+
+		$extractor = new WP_Document_Revisions_DOCX_Text_Extractor();
+		$text      = $extractor->extract( $path, self::DOCX_MIME );
+
+		self::assertStringContainsString( 'Document header line', $text );
+		self::assertStringContainsString( 'Body paragraph', $text );
+		self::assertStringContainsString( 'Document footer line', $text );
+	}
+
+	/**
+	 * Pulls text from a TextRun's inner Text elements (formatted runs).
+	 */
+	public function test_extract_returns_text_run_content() {
+		$path = $this->build_document(
+			static function ( \PhpOffice\PhpWord\PhpWord $phpword ): void {
+				$section = $phpword->addSection();
+				$run     = $section->addTextRun();
+				$run->addText( 'Bold-ish ', array( 'bold' => true ) );
+				$run->addText( 'plain.' );
+			}
+		);
+
+		$extractor = new WP_Document_Revisions_DOCX_Text_Extractor();
+		$text      = $extractor->extract( $path, self::DOCX_MIME );
+
+		self::assertStringContainsString( 'Bold-ish', $text );
+		self::assertStringContainsString( 'plain.', $text );
+	}
+
+	/**
+	 * Pulls text from list items.
+	 */
+	public function test_extract_returns_list_item_text() {
+		$path = $this->build_document(
+			static function ( \PhpOffice\PhpWord\PhpWord $phpword ): void {
+				$section = $phpword->addSection();
+				$section->addListItem( 'First bullet' );
+				$section->addListItem( 'Second bullet' );
+			}
+		);
+
+		$extractor = new WP_Document_Revisions_DOCX_Text_Extractor();
+		$text      = $extractor->extract( $path, self::DOCX_MIME );
+
+		self::assertStringContainsString( 'First bullet', $text );
+		self::assertStringContainsString( 'Second bullet', $text );
+	}
+
+	/**
+	 * Reads ODT via the ODText reader.
+	 */
+	public function test_extract_reads_odt_format() {
+		$path = $this->build_document(
+			static function ( \PhpOffice\PhpWord\PhpWord $phpword ): void {
+				$section = $phpword->addSection();
+				$section->addText( 'OpenDocument text content.' );
+			},
+			'ODText',
+			'.odt'
+		);
+
+		$extractor = new WP_Document_Revisions_DOCX_Text_Extractor();
+		$text      = $extractor->extract( $path, self::ODT_MIME );
+
+		self::assertStringContainsString( 'OpenDocument text content.', $text );
+	}
+
+	/**
+	 * Returns an empty string when handed a missing file.
+	 */
+	public function test_extract_returns_empty_for_missing_file() {
+		$extractor = new WP_Document_Revisions_DOCX_Text_Extractor();
+
+		self::assertSame( '', $extractor->extract( '/no/such/file.docx', self::DOCX_MIME ) );
+	}
+
+	/**
+	 * Returns an empty string when handed plain text masquerading as a DOCX
+	 * (PHPWord throws, the extractor catches).
+	 */
+	public function test_extract_returns_empty_for_non_docx_content() {
+		$extractor = new WP_Document_Revisions_DOCX_Text_Extractor();
+
+		self::assertSame( '', $extractor->extract( self::$test_file, self::DOCX_MIME ) );
+	}
+
+	/**
+	 * The plugin bootstrap auto-registers the DOCX extractor.
+	 */
+	public function test_docx_extractor_is_registered_by_default() {
+		$extractors = WP_Document_Revisions_Text_Extractor_Registry::get_extractors();
+
+		$has_docx = false;
+		foreach ( $extractors as $extractor ) {
+			if ( $extractor instanceof WP_Document_Revisions_DOCX_Text_Extractor ) {
+				$has_docx = true;
+				break;
+			}
+		}
+
+		self::assertTrue( $has_docx, 'Expected WP_Document_Revisions_DOCX_Text_Extractor in the default registry' );
+	}
+
+	/**
+	 * The registry resolves the DOCX MIME type to the built-in extractor.
+	 */
+	public function test_registry_resolves_docx_to_built_in_extractor() {
+		$extractor = WP_Document_Revisions_Text_Extractor_Registry::find_for( self::DOCX_MIME );
+
+		self::assertInstanceOf( WP_Document_Revisions_DOCX_Text_Extractor::class, $extractor );
+	}
+
+	/**
+	 * The registry resolves the ODT MIME type to the same built-in extractor.
+	 */
+	public function test_registry_resolves_odt_to_built_in_extractor() {
+		$extractor = WP_Document_Revisions_Text_Extractor_Registry::find_for( self::ODT_MIME );
+
+		self::assertInstanceOf( WP_Document_Revisions_DOCX_Text_Extractor::class, $extractor );
+	}
+
+	/**
+	 * End-to-end: wpdr_extract_text() routes a DOCX attachment to the
+	 * built-in extractor and returns the document's text.
+	 */
+	public function test_wpdr_extract_text_runs_docx_extractor_against_attachment() {
+		$docx_path = $this->build_document(
+			static function ( \PhpOffice\PhpWord\PhpWord $phpword ): void {
+				$section = $phpword->addSection();
+				$section->addText( 'Integration test content.' );
+			}
+		);
+
+		$doc_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'DOCX Extractor Document',
+				'post_type'   => 'document',
+				'post_status' => 'publish',
+			)
+		);
+		self::add_document_attachment( self::factory(), $doc_id, $docx_path );
+
+		global $wpdr;
+		$revision  = $wpdr->get_latest_revision( $doc_id );
+		$attach_id = (int) $revision->post_content;
+
+		$text = wpdr_extract_text( $attach_id );
+
+		self::assertStringContainsString( 'Integration test content.', $text );
+	}
+}

--- a/tests/class-test-wp-document-revisions-docx-text-extractor.php
+++ b/tests/class-test-wp-document-revisions-docx-text-extractor.php
@@ -311,7 +311,7 @@ class Test_WP_Document_Revisions_DOCX_Text_Extractor extends Test_Common_WPDR {
 		$text = wpdr_extract_text( $attach_id );
 
 		$diagnostic = sprintf(
-			"path=%s exists=%s readable=%s mime=%s direct_extract_len=%d wpdr_extract_len=%d",
+			'path=%s exists=%s readable=%s mime=%s direct_extract_len=%d wpdr_extract_len=%d',
 			$attached_path,
 			( $attached_path && file_exists( $attached_path ) ) ? 'yes' : 'no',
 			( $attached_path && is_readable( $attached_path ) ) ? 'yes' : 'no',

--- a/tests/class-test-wp-document-revisions-docx-text-extractor.php
+++ b/tests/class-test-wp-document-revisions-docx-text-extractor.php
@@ -44,7 +44,7 @@ class Test_WP_Document_Revisions_DOCX_Text_Extractor extends Test_Common_WPDR {
 	public function tear_down() {
 		foreach ( $this->temp_files as $path ) {
 			if ( file_exists( $path ) ) {
-				unlink( $path );
+				wp_delete_file( $path );
 			}
 		}
 		$this->temp_files = array();
@@ -64,18 +64,17 @@ class Test_WP_Document_Revisions_DOCX_Text_Extractor extends Test_Common_WPDR {
 		$phpword = new \PhpOffice\PhpWord\PhpWord();
 		$builder( $phpword );
 
-		$path = tempnam( sys_get_temp_dir(), 'wpdr_test_' );
-		// tempnam returns a path with no extension; rename so PHPWord picks
-		// the right reader hint on load and the file name reads naturally
-		// in any debugging output.
-		$with_ext = $path . $ext;
-		rename( $path, $with_ext );
+		// wp_tempnam() gives us a unique path inside the WP upload tree;
+		// pass the desired suffix so PHPWord's writer sees a sensible
+		// extension when it saves and the file name reads naturally in
+		// any debugging output.
+		$path = wp_tempnam( 'wpdr_test_' . wp_generate_password( 6, false ) . $ext );
 
 		$writer_obj = \PhpOffice\PhpWord\IOFactory::createWriter( $phpword, $writer );
-		$writer_obj->save( $with_ext );
+		$writer_obj->save( $path );
 
-		$this->temp_files[] = $with_ext;
-		return $with_ext;
+		$this->temp_files[] = $path;
+		return $path;
 	}
 
 	/**

--- a/tests/class-test-wp-document-revisions-docx-text-extractor.php
+++ b/tests/class-test-wp-document-revisions-docx-text-extractor.php
@@ -55,6 +55,13 @@ class Test_WP_Document_Revisions_DOCX_Text_Extractor extends Test_Common_WPDR {
 	 * Build a PhpWord document with caller-supplied content and persist it
 	 * to a temp file via the requested writer.
 	 *
+	 * The file extension is part of the contract: downstream code
+	 * (`wp_check_filetype` in particular) keys the MIME type off the
+	 * extension, and `wp_tempnam()` cannot be used here because it
+	 * unconditionally rewrites the suffix to `.tmp` regardless of input,
+	 * which then propagates to the attachment's MIME being empty and the
+	 * registry not matching any extractor.
+	 *
 	 * @param callable $builder receives a PhpWord instance, populates it.
 	 * @param string   $writer  PHPWord writer name ('Word2007' or 'ODText').
 	 * @param string   $ext     file extension to use for the temp file.
@@ -64,11 +71,9 @@ class Test_WP_Document_Revisions_DOCX_Text_Extractor extends Test_Common_WPDR {
 		$phpword = new \PhpOffice\PhpWord\PhpWord();
 		$builder( $phpword );
 
-		// wp_tempnam() gives us a unique path inside the WP upload tree;
-		// pass the desired suffix so PHPWord's writer sees a sensible
-		// extension when it saves and the file name reads naturally in
-		// any debugging output.
-		$path = wp_tempnam( 'wpdr_test_' . wp_generate_password( 6, false ) . $ext );
+		$dir  = trailingslashit( get_temp_dir() );
+		$name = wp_unique_filename( $dir, 'wpdr_test_' . wp_generate_password( 12, false ) . $ext );
+		$path = $dir . $name;
 
 		$writer_obj = \PhpOffice\PhpWord\IOFactory::createWriter( $phpword, $writer );
 		$writer_obj->save( $path );
@@ -298,28 +303,8 @@ class Test_WP_Document_Revisions_DOCX_Text_Extractor extends Test_Common_WPDR {
 		$revision  = $wpdr->get_latest_revision( $doc_id );
 		$attach_id = (int) $revision->post_content;
 
-		// Diagnostic state in case the assertion below fails: print what
-		// wpdr_extract_text() actually sees so we don't have to guess at
-		// the wp_upload_dir filter / MIME / path interaction.
-		$attached_path = get_attached_file( $attach_id );
-		$attached_mime = get_post_mime_type( $attach_id );
-		$direct_text   = ( new WP_Document_Revisions_DOCX_Text_Extractor() )->extract(
-			(string) $attached_path,
-			(string) $attached_mime
-		);
-
 		$text = wpdr_extract_text( $attach_id );
 
-		$diagnostic = sprintf(
-			'path=%s exists=%s readable=%s mime=%s direct_extract_len=%d wpdr_extract_len=%d',
-			$attached_path,
-			( $attached_path && file_exists( $attached_path ) ) ? 'yes' : 'no',
-			( $attached_path && is_readable( $attached_path ) ) ? 'yes' : 'no',
-			$attached_mime,
-			strlen( $direct_text ),
-			strlen( $text )
-		);
-
-		self::assertStringContainsString( 'Integration test content.', $text, $diagnostic );
+		self::assertStringContainsString( 'Integration test content.', $text );
 	}
 }

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -97,16 +97,24 @@ require_once __DIR__ . '/includes/interface-wp-document-revisions-text-extractor
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-extraction-exception.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-extractor-registry.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-pdf-text-extractor.php';
+require_once __DIR__ . '/includes/class-wp-document-revisions-docx-text-extractor.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions.php';
 
-// Register the built-in PDF text extractor. Lazy construction inside the
-// filter callback avoids paying the parser allocation cost on requests that
-// never extract anything. Third parties can prepend their own extractors at
-// a higher priority to override this one.
+// Register the built-in text extractors. Lazy construction inside the filter
+// callbacks avoids paying allocation cost on requests that never extract
+// anything. Third parties can prepend their own extractors at a higher
+// filter priority to override these defaults.
 add_filter(
 	'wpdr_text_extractors',
 	static function ( array $extractors ): array {
 		$extractors[] = new WP_Document_Revisions_PDF_Text_Extractor();
+		return $extractors;
+	}
+);
+add_filter(
+	'wpdr_text_extractors',
+	static function ( array $extractors ): array {
+		$extractors[] = new WP_Document_Revisions_DOCX_Text_Extractor();
 		return $extractors;
 	}
 );


### PR DESCRIPTION
## Summary

Phase 4 of issue #514. Second concrete extractor on top of phases 1 (interface), 3a (autoload shim), and 3b (PDF).

### What lands

- **`phpoffice/phpword ^1.3`** in `composer.json` `require`, alongside `smalot/pdfparser`.
- **`WP_Document_Revisions_DOCX_Text_Extractor`** — handles `application/vnd.openxmlformats-officedocument.wordprocessingml.document` (DOCX) and, as a bonus, `application/vnd.oasis.opendocument.text` (ODT — PHPWord reads it). Legacy `application/msword` is intentionally not matched here; that's phase 5.
- **Element walker** — loads documents via `PhpOffice\PhpWord\IOFactory` (`Word2007` or `ODText` reader keyed off the MIME type) and walks the element tree by `instanceof`: `Text`, `TextRun`, `Table` (rows + cells, cells joined with tabs, rows with newlines), `ListItem`. Sections additionally walk `getHeaders()` and `getFooters()`. Unrecognised containers fall through to a generic `getElements()` walk so future PHPWord element types don't silently drop text.
- **`catch (\Throwable)`** returns empty on any parse failure (encrypted, malformed, unsupported), matching the PDF extractor's contract.
- **Auto-registration** via a second `add_filter('wpdr_text_extractors', ...)` mirroring phase 3b's PDF callback. Two extractors don't justify a `register_default_extractors()` helper yet — wait for a third.

### Test coverage

`tests/class-test-wp-document-revisions-docx-text-extractor.php`:

- `supports()` accepts DOCX + ODT, rejects `application/msword`, `application/pdf`, `text/plain`, empty.
- Plain paragraphs, tables (rows/cells), headers/footers, formatted `TextRun`, list items.
- ODT round-trip via the ODText reader.
- Negative: missing file, non-DOCX content (plain text masquerading as DOCX).
- Auto-registration: extractor present in the default registry; both DOCX and ODT MIME types resolve to it.
- End-to-end `wpdr_extract_text()` against a DOCX attachment.

### Fixture limitation (flagged)

Per the PR-thread decision, fixtures are **generated programmatically with PHPWord in test setup** rather than checked in. This means the tests exercise the PHPWord writer + extractor as a pair — a bug in PHPWord's writer masked by a matching bug in its reader would pass silently. Real-world DOCX from Word and LibreOffice has structural quirks PHPWord-produced files don't reproduce.

Follow-up should drop small fixture files produced by actual Word + LibreOffice into `tests/documents/` and exercise the extractor against those paths.

### Intentionally not in scope

- Legacy `.doc` (`application/msword`) — phase 5 (shell out to LibreOffice/antiword).
- Caching extracted text — phase 6.
- Async scheduling — phase 7.
- Real-world DOCX/ODT fixtures — follow-up.

## Test plan

- [ ] `code-quality` (phpcs, phpstan, audit including phpword) passes
- [ ] `phpunit` matrix passes; new `Test_WP_Document_Revisions_DOCX_Text_Extractor` green across PHP 8.0–8.3
- [ ] Plain `composer install` resolves phpword + smalot cleanly together
- [ ] No CI extension changes needed (assumes shivammathur/setup-php default extensions cover phpword's `ext-zip`, `ext-xml`)

Closes part of #514 (phase 4 of 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)