### PR TITLE
Add SHA-256-keyed cache for extracted text (#514, phase 6)

### DIFF
--- a/includes/class-wp-document-revisions-text-extractor-cache.php
+++ b/includes/class-wp-document-revisions-text-extractor-cache.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * SHA-256-keyed cache for extracted text.
+ *
+ * Stored as post meta on the revision attachment:
+ *   _wpdr_extracted_text       — the extracted plain text (may be empty)
+ *   _wpdr_extracted_text_hash  — SHA-256 of the file at the time of extraction
+ *
+ * `get()` returns a `?string`: `null` for a cache miss (no meta, or the
+ * file's current hash does not match the stored one), or the cached string
+ * (possibly empty) on hit. This distinction lets callers tell the difference
+ * between "not extracted yet" and "extracted to an empty string" (e.g., a
+ * scanned PDF or a password-protected file) without re-running the extractor.
+ *
+ * Phase 6 caches every result, including `''`. Phase 7 will layer a
+ * `_wpdr_extraction_failed` flag on top to distinguish empty-by-design from
+ * extractor-failed — until then, this cache treats all returns from the
+ * registry as cacheable and invalidates them only when the file content
+ * changes.
+ *
+ * @since 4.1.0
+ * @package WP_Document_Revisions
+ */
+
+// direct file access protection.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Hash-keyed post-meta cache for extracted document text.
+ */
+class WP_Document_Revisions_Text_Extractor_Cache {
+
+	/**
+	 * Post meta key for the cached extracted text.
+	 *
+	 * @var string
+	 */
+	const META_KEY_TEXT = '_wpdr_extracted_text';
+
+	/**
+	 * Post meta key for the SHA-256 of the file at extraction time.
+	 *
+	 * @var string
+	 */
+	const META_KEY_HASH = '_wpdr_extracted_text_hash';
+
+	/**
+	 * Look up cached text for an attachment whose file hash matches the
+	 * stored one.
+	 *
+	 * @param int    $attachment_id ID of the revision attachment post.
+	 * @param string $file_path     absolute path to the current file on disk.
+	 * @return string|null cached text on hit (possibly empty), null on miss.
+	 */
+	public static function get( int $attachment_id, string $file_path ): ?string {
+		if ( $attachment_id <= 0 ) {
+			return null;
+		}
+
+		$current_hash = self::file_hash( $file_path );
+		if ( null === $current_hash ) {
+			return null;
+		}
+
+		$cached_hash = (string) get_post_meta( $attachment_id, self::META_KEY_HASH, true );
+		if ( '' === $cached_hash || $cached_hash !== $current_hash ) {
+			return null;
+		}
+
+		$cached_text = get_post_meta( $attachment_id, self::META_KEY_TEXT, true );
+		// Meta returns '' when unset, which we tolerate as "cached as empty
+		// extraction". The hash match above is what proves the cache hit.
+		return is_string( $cached_text ) ? $cached_text : '';
+	}
+
+	/**
+	 * Store extracted text and the SHA-256 of the file it came from.
+	 *
+	 * Silently no-ops on invalid attachment IDs or unhashable files so a
+	 * caching failure cannot break the calling extraction path.
+	 *
+	 * @param int    $attachment_id ID of the revision attachment post.
+	 * @param string $file_path     absolute path to the file the text came from.
+	 * @param string $text          extracted text to cache (may be empty).
+	 * @return void
+	 */
+	public static function set( int $attachment_id, string $file_path, string $text ): void {
+		if ( $attachment_id <= 0 ) {
+			return;
+		}
+
+		$current_hash = self::file_hash( $file_path );
+		if ( null === $current_hash ) {
+			return;
+		}
+
+		update_post_meta( $attachment_id, self::META_KEY_TEXT, $text );
+		update_post_meta( $attachment_id, self::META_KEY_HASH, $current_hash );
+	}
+
+	/**
+	 * Hash a file with SHA-256, returning null on any I/O failure.
+	 *
+	 * @param string $file_path absolute path to a readable file.
+	 * @return string|null hex-encoded SHA-256, or null on failure.
+	 */
+	private static function file_hash( string $file_path ): ?string {
+		if ( '' === $file_path || ! is_readable( $file_path ) ) {
+			return null;
+		}
+		$hash = hash_file( 'sha256', $file_path );
+		return false === $hash ? null : $hash;
+	}
+}

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -66,8 +66,10 @@ if ( ! function_exists( 'wpdr_extract_text' ) ) {
 	 * Returns an empty string if no extractor is registered for the type, the
 	 * file is missing, or the extractor declines to produce text.
 	 *
-	 * Phase 1 of issue #514: pure dispatch, no caching. Caching and async
-	 * scheduling land in later phases.
+	 * Phase 6 of issue #514 wraps the registry dispatch with a SHA-256-keyed
+	 * post-meta cache: subsequent calls against the same revision and the
+	 * same file return the cached text without re-running the extractor. The
+	 * cache invalidates automatically whenever the file content changes.
 	 *
 	 * @since 4.1.0
 	 *
@@ -79,9 +81,23 @@ if ( ! function_exists( 'wpdr_extract_text' ) ) {
 			return '';
 		}
 
-		$file_path = get_attached_file( $revision_id );
-		if ( ! is_string( $file_path ) || '' === $file_path ) {
+		// Cache lives on the attachment post; bail (without touching the
+		// cache) if someone passes a parent document or another post type.
+		if ( 'attachment' !== get_post_type( $revision_id ) ) {
 			return '';
+		}
+
+		$file_path = get_attached_file( $revision_id );
+		if ( ! is_string( $file_path ) || '' === $file_path || ! is_readable( $file_path ) ) {
+			// Unreadable file: do NOT invalidate or overwrite the cache —
+			// a transient I/O blip shouldn't blow away previously-extracted
+			// text. Return '' for this call only.
+			return '';
+		}
+
+		$cached = WP_Document_Revisions_Text_Extractor_Cache::get( $revision_id, $file_path );
+		if ( null !== $cached ) {
+			return $cached;
 		}
 
 		$mime_type = get_post_mime_type( $revision_id );
@@ -89,6 +105,8 @@ if ( ! function_exists( 'wpdr_extract_text' ) ) {
 			return '';
 		}
 
-		return WP_Document_Revisions_Text_Extractor_Registry::extract( $file_path, $mime_type );
+		$text = WP_Document_Revisions_Text_Extractor_Registry::extract( $file_path, $mime_type );
+		WP_Document_Revisions_Text_Extractor_Cache::set( $revision_id, $file_path, $text );
+		return $text;
 	}
 }

--- a/tests/class-test-wp-document-revisions-text-extractor-cache.php
+++ b/tests/class-test-wp-document-revisions-text-extractor-cache.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * Tests for the SHA-256-keyed extracted-text cache.
+ *
+ * Phase 6 of issue #514: verifies that a second wpdr_extract_text() call
+ * against the same revision and the same file does not re-invoke the
+ * extractor, and that the cache invalidates when the file content changes.
+ *
+ * @package WP_Document_Revisions
+ */
+
+/**
+ * Tests for WP_Document_Revisions_Text_Extractor_Cache + wpdr_extract_text() caching.
+ */
+class Test_WP_Document_Revisions_Text_Extractor_Cache extends Test_Common_WPDR {
+
+	/**
+	 * Load the counting-fake helper class once per test class run.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once __DIR__ . '/class-wpdr-test-counting-text-extractor.php';
+	}
+
+	/**
+	 * Clear filters and cache meta so tests don't leak.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'wpdr_text_extractors' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Register a counting fake extractor for application/octet-stream so
+	 * the built-in PDF/DOCX extractors don't shadow it, and so we have a
+	 * stable instance whose call count we can read.
+	 *
+	 * @param string $mime MIME type the fake should claim.
+	 * @return WPDR_Test_Counting_Text_Extractor the registered fake.
+	 */
+	private function register_counting_fake( string $mime = 'text/plain' ): WPDR_Test_Counting_Text_Extractor {
+		$fake = new WPDR_Test_Counting_Text_Extractor( $mime );
+		add_filter(
+			'wpdr_text_extractors',
+			static function ( array $extractors ) use ( $fake ): array {
+				array_unshift( $extractors, $fake );
+				return $extractors;
+			}
+		);
+		return $fake;
+	}
+
+	/**
+	 * Create a document + attached text file, return the attachment ID.
+	 *
+	 * @return int attachment ID.
+	 */
+	private function create_text_attachment(): int {
+		$doc_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Cache Test Document',
+				'post_type'   => 'document',
+				'post_status' => 'publish',
+			)
+		);
+		self::add_document_attachment( self::factory(), $doc_id, self::$test_file );
+
+		global $wpdr;
+		$revision = $wpdr->get_latest_revision( $doc_id );
+		return (int) $revision->post_content;
+	}
+
+	/**
+	 * Cache::get returns null when no meta has been written yet.
+	 */
+	public function test_cache_get_returns_null_on_miss() {
+		$attach_id = $this->create_text_attachment();
+
+		$file_path = get_attached_file( $attach_id );
+		self::assertNull( WP_Document_Revisions_Text_Extractor_Cache::get( $attach_id, $file_path ) );
+	}
+
+	/**
+	 * Cache::set followed by Cache::get returns the stored text.
+	 */
+	public function test_cache_set_then_get_returns_stored_text() {
+		$attach_id = $this->create_text_attachment();
+		$file_path = get_attached_file( $attach_id );
+
+		WP_Document_Revisions_Text_Extractor_Cache::set( $attach_id, $file_path, 'hello cache' );
+
+		self::assertSame( 'hello cache', WP_Document_Revisions_Text_Extractor_Cache::get( $attach_id, $file_path ) );
+	}
+
+	/**
+	 * Cache stores empty strings — a legitimate "extractor returned nothing"
+	 * is distinguishable from "not cached yet" via the hash check.
+	 */
+	public function test_cache_set_then_get_returns_empty_string_distinctly() {
+		$attach_id = $this->create_text_attachment();
+		$file_path = get_attached_file( $attach_id );
+
+		WP_Document_Revisions_Text_Extractor_Cache::set( $attach_id, $file_path, '' );
+
+		self::assertSame( '', WP_Document_Revisions_Text_Extractor_Cache::get( $attach_id, $file_path ) );
+	}
+
+	/**
+	 * Cache::get returns null when the file content has changed since the
+	 * cached hash was written.
+	 */
+	public function test_cache_get_returns_null_when_file_hash_differs() {
+		$attach_id = $this->create_text_attachment();
+		$file_path = get_attached_file( $attach_id );
+
+		WP_Document_Revisions_Text_Extractor_Cache::set( $attach_id, $file_path, 'old text' );
+
+		// Overwrite the file's contents so the SHA-256 changes.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $file_path, 'new file body that differs from the original' );
+
+		self::assertNull( WP_Document_Revisions_Text_Extractor_Cache::get( $attach_id, $file_path ) );
+	}
+
+	/**
+	 * Cache::get returns null for a non-existent file path.
+	 */
+	public function test_cache_get_returns_null_for_unreadable_file() {
+		$attach_id = $this->create_text_attachment();
+
+		self::assertNull(
+			WP_Document_Revisions_Text_Extractor_Cache::get( $attach_id, '/no/such/file.txt' )
+		);
+	}
+
+	/**
+	 * Cache::get and Cache::set are no-ops on invalid attachment IDs.
+	 */
+	public function test_cache_handles_invalid_attachment_id() {
+		self::assertNull( WP_Document_Revisions_Text_Extractor_Cache::get( 0, self::$test_file ) );
+		self::assertNull( WP_Document_Revisions_Text_Extractor_Cache::get( -1, self::$test_file ) );
+
+		// set() should silently no-op rather than throwing.
+		WP_Document_Revisions_Text_Extractor_Cache::set( 0, self::$test_file, 'irrelevant' );
+		WP_Document_Revisions_Text_Extractor_Cache::set( -1, self::$test_file, 'irrelevant' );
+	}
+
+	/**
+	 * First wpdr_extract_text() call invokes the extractor and writes the
+	 * cache; the second call against the same revision and the same file
+	 * content returns the cached text without re-invoking the extractor.
+	 */
+	public function test_wpdr_extract_text_caches_after_first_call() {
+		$fake      = $this->register_counting_fake();
+		$attach_id = $this->create_text_attachment();
+
+		$text1 = wpdr_extract_text( $attach_id );
+		self::assertSame( 1, $fake->calls, 'First call should invoke the extractor exactly once' );
+		self::assertNotSame( '', $text1, 'Test fixture is non-empty, so first extraction should return text' );
+
+		$text2 = wpdr_extract_text( $attach_id );
+		self::assertSame( 1, $fake->calls, 'Second call should be served from cache' );
+		self::assertSame( $text1, $text2 );
+	}
+
+	/**
+	 * Cache invalidates when the underlying file's content changes — the
+	 * next wpdr_extract_text() call re-invokes the extractor against the
+	 * new content.
+	 */
+	public function test_wpdr_extract_text_reruns_when_file_content_changes() {
+		$fake      = $this->register_counting_fake();
+		$attach_id = $this->create_text_attachment();
+
+		wpdr_extract_text( $attach_id );
+		self::assertSame( 1, $fake->calls );
+
+		$file_path = get_attached_file( $attach_id );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $file_path, 'updated body content' );
+
+		$text = wpdr_extract_text( $attach_id );
+		self::assertSame( 2, $fake->calls, 'Hash mismatch should trigger re-extraction' );
+		self::assertStringContainsString( 'updated body content', $text );
+	}
+
+	/**
+	 * Cache is keyed per attachment: a second attachment with different
+	 * content does not share the first one's cached text.
+	 */
+	public function test_cache_isolated_per_attachment() {
+		$fake = $this->register_counting_fake();
+
+		$first  = $this->create_text_attachment();
+		$second = $this->create_text_attachment();
+
+		wpdr_extract_text( $first );
+		wpdr_extract_text( $second );
+
+		self::assertSame( 2, $fake->calls, 'Each attachment should miss its own cache on first call' );
+
+		wpdr_extract_text( $first );
+		wpdr_extract_text( $second );
+
+		self::assertSame( 2, $fake->calls, 'Subsequent calls should be served from cache for each attachment' );
+	}
+
+	/**
+	 * Caching an empty extraction prevents the extractor from running again
+	 * on subsequent reads — important so a scanned PDF or password-protected
+	 * file is parsed at most once per file revision.
+	 */
+	public function test_wpdr_extract_text_caches_empty_extractions() {
+		$fake = new class() implements WP_Document_Revisions_Text_Extractor {
+			public $calls = 0;
+
+			public function supports( string $mime_type ): bool {
+				return 'text/plain' === $mime_type;
+			}
+
+			public function extract( string $file_path, string $mime_type ): string {
+				unset( $file_path, $mime_type );
+				++$this->calls;
+				return '';
+			}
+		};
+
+		add_filter(
+			'wpdr_text_extractors',
+			static function ( array $extractors ) use ( $fake ): array {
+				array_unshift( $extractors, $fake );
+				return $extractors;
+			}
+		);
+
+		$attach_id = $this->create_text_attachment();
+
+		self::assertSame( '', wpdr_extract_text( $attach_id ) );
+		self::assertSame( 1, $fake->calls );
+
+		self::assertSame( '', wpdr_extract_text( $attach_id ) );
+		self::assertSame( 1, $fake->calls, 'Empty extraction should still be served from cache on the second call' );
+	}
+
+	/**
+	 * Passing a non-attachment post ID returns '' without touching the
+	 * cache (defensive guard against a caller passing the parent document
+	 * ID instead of the attachment ID).
+	 */
+	public function test_wpdr_extract_text_refuses_non_attachment_post() {
+		$fake   = $this->register_counting_fake();
+		$doc_id = self::factory()->post->create(
+			array(
+				'post_title' => 'Just a regular post',
+				'post_type'  => 'post',
+			)
+		);
+
+		self::assertSame( '', wpdr_extract_text( $doc_id ) );
+		self::assertSame( 0, $fake->calls, 'Non-attachment posts should not reach the extractor' );
+
+		// Cache should not have been written either.
+		self::assertSame(
+			'',
+			(string) get_post_meta( $doc_id, WP_Document_Revisions_Text_Extractor_Cache::META_KEY_HASH, true )
+		);
+	}
+
+	/**
+	 * An unreadable file path does not wipe a previously-cached extraction.
+	 * Simulates a transient I/O blip on a real revision.
+	 */
+	public function test_unreadable_file_does_not_invalidate_existing_cache() {
+		$fake      = $this->register_counting_fake();
+		$attach_id = $this->create_text_attachment();
+
+		$text = wpdr_extract_text( $attach_id );
+		self::assertSame( 1, $fake->calls );
+
+		// Move the file away so the next get_attached_file() returns a path
+		// that no longer exists.
+		$file_path  = get_attached_file( $attach_id );
+		$moved_path = $file_path . '.bak';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
+		rename( $file_path, $moved_path );
+
+		try {
+			$during = wpdr_extract_text( $attach_id );
+			self::assertSame( '', $during, 'Unreadable file should yield empty for this call' );
+			self::assertSame( 1, $fake->calls, 'Extractor should not run on an unreadable file' );
+		} finally {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
+			rename( $moved_path, $file_path );
+		}
+
+		// And the cache should still be there once the file is back.
+		$after = wpdr_extract_text( $attach_id );
+		self::assertSame( 1, $fake->calls, 'Cache should still serve the original text after the file is restored' );
+		self::assertSame( $text, $after );
+	}
+}

--- a/tests/class-test-wp-document-revisions-text-extractor-cache.php
+++ b/tests/class-test-wp-document-revisions-text-extractor-cache.php
@@ -31,15 +31,16 @@ class Test_WP_Document_Revisions_Text_Extractor_Cache extends Test_Common_WPDR {
 	}
 
 	/**
-	 * Register a counting fake extractor for application/octet-stream so
-	 * the built-in PDF/DOCX extractors don't shadow it, and so we have a
-	 * stable instance whose call count we can read.
+	 * Register a counting fake extractor at a higher priority than the
+	 * built-ins so we have a stable instance whose call count we can read.
 	 *
-	 * @param string $mime MIME type the fake should claim.
+	 * @param string      $mime         MIME type the fake should claim.
+	 * @param string|null $fixed_return Optional fixed extract() return; null
+	 *                                  means read the file's contents.
 	 * @return WPDR_Test_Counting_Text_Extractor the registered fake.
 	 */
-	private function register_counting_fake( string $mime = 'text/plain' ): WPDR_Test_Counting_Text_Extractor {
-		$fake = new WPDR_Test_Counting_Text_Extractor( $mime );
+	private function register_counting_fake( string $mime = 'text/plain', ?string $fixed_return = null ): WPDR_Test_Counting_Text_Extractor {
+		$fake = new WPDR_Test_Counting_Text_Extractor( $mime, $fixed_return );
 		add_filter(
 			'wpdr_text_extractors',
 			static function ( array $extractors ) use ( $fake ): array {
@@ -211,28 +212,9 @@ class Test_WP_Document_Revisions_Text_Extractor_Cache extends Test_Common_WPDR {
 	 * file is parsed at most once per file revision.
 	 */
 	public function test_wpdr_extract_text_caches_empty_extractions() {
-		$fake = new class() implements WP_Document_Revisions_Text_Extractor {
-			public $calls = 0;
-
-			public function supports( string $mime_type ): bool {
-				return 'text/plain' === $mime_type;
-			}
-
-			public function extract( string $file_path, string $mime_type ): string {
-				unset( $file_path, $mime_type );
-				++$this->calls;
-				return '';
-			}
-		};
-
-		add_filter(
-			'wpdr_text_extractors',
-			static function ( array $extractors ) use ( $fake ): array {
-				array_unshift( $extractors, $fake );
-				return $extractors;
-			}
-		);
-
+		// Configure the fake to return '' so we exercise the
+		// "extractor returned empty" branch without depending on file content.
+		$fake      = $this->register_counting_fake( 'text/plain', '' );
 		$attach_id = $this->create_text_attachment();
 
 		self::assertSame( '', wpdr_extract_text( $attach_id ) );

--- a/tests/class-wpdr-test-counting-text-extractor.php
+++ b/tests/class-wpdr-test-counting-text-extractor.php
@@ -29,12 +29,25 @@ class WPDR_Test_Counting_Text_Extractor implements WP_Document_Revisions_Text_Ex
 	private $supported_mime;
 
 	/**
+	 * Fixed string to return from extract(), or null to read the file.
+	 *
+	 * @var string|null
+	 */
+	private $fixed_return;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param string $supported_mime MIME type this fake claims.
+	 * @param string      $supported_mime MIME type this fake claims.
+	 * @param string|null $fixed_return   When set, extract() returns this
+	 *                                    instead of reading the file. Lets
+	 *                                    callers exercise the "extractor
+	 *                                    returned ''" path without depending
+	 *                                    on file content.
 	 */
-	public function __construct( string $supported_mime = 'text/plain' ) {
+	public function __construct( string $supported_mime = 'text/plain', ?string $fixed_return = null ) {
 		$this->supported_mime = $supported_mime;
+		$this->fixed_return   = $fixed_return;
 	}
 
 	/**
@@ -58,6 +71,9 @@ class WPDR_Test_Counting_Text_Extractor implements WP_Document_Revisions_Text_Ex
 	public function extract( string $file_path, string $mime_type ): string {
 		unset( $mime_type );
 		++$this->calls;
+		if ( null !== $this->fixed_return ) {
+			return $this->fixed_return;
+		}
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$contents = file_get_contents( $file_path );
 		return false === $contents ? '' : (string) $contents;

--- a/tests/class-wpdr-test-counting-text-extractor.php
+++ b/tests/class-wpdr-test-counting-text-extractor.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Test double: text extractor that counts how many times extract() runs.
+ *
+ * Used by the cache tests to verify a second wpdr_extract_text() call
+ * against the same revision and the same file content does NOT re-invoke
+ * the extractor.
+ *
+ * @package WP_Document_Revisions
+ */
+
+/**
+ * Counting fake extractor for cache tests.
+ */
+class WPDR_Test_Counting_Text_Extractor implements WP_Document_Revisions_Text_Extractor {
+
+	/**
+	 * Number of times extract() has been called on this instance.
+	 *
+	 * @var int
+	 */
+	public $calls = 0;
+
+	/**
+	 * MIME type this fake claims to support.
+	 *
+	 * @var string
+	 */
+	private $supported_mime;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $supported_mime MIME type this fake claims.
+	 */
+	public function __construct( string $supported_mime = 'text/plain' ) {
+		$this->supported_mime = $supported_mime;
+	}
+
+	/**
+	 * Supports check.
+	 *
+	 * @param string $mime_type MIME type to check.
+	 * @return bool
+	 */
+	public function supports( string $mime_type ): bool {
+		return $mime_type === $this->supported_mime;
+	}
+
+	/**
+	 * Extract — counts the call and returns the file's current contents
+	 * so a content change is observable in the cached value.
+	 *
+	 * @param string $file_path file path.
+	 * @param string $mime_type MIME type.
+	 * @return string
+	 */
+	public function extract( string $file_path, string $mime_type ): string {
+		unset( $mime_type );
+		++$this->calls;
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$contents = file_get_contents( $file_path );
+		return false === $contents ? '' : (string) $contents;
+	}
+}

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -96,6 +96,7 @@ require_once __DIR__ . '/includes/trait-wp-document-revisions-query.php';
 require_once __DIR__ . '/includes/interface-wp-document-revisions-text-extractor.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-extraction-exception.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-extractor-registry.php';
+require_once __DIR__ . '/includes/class-wp-document-revisions-text-extractor-cache.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-pdf-text-extractor.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-docx-text-extractor.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions.php';


### PR DESCRIPTION
## Summary

Phase 6 of issue #514. Wraps the registry dispatch with a hash-keyed post-meta cache so a second `wpdr_extract_text()` call against the same revision and the same file content returns the cached string without re-running the extractor. Cache invalidates automatically whenever the file content changes (re-upload, in-place edit, etc.).

### What lands

- **`WP_Document_Revisions_Text_Extractor_Cache`** (`includes/class-wp-document-revisions-text-extractor-cache.php`)
  - Two class constants for the meta keys (`_wpdr_extracted_text`, `_wpdr_extracted_text_hash`) so later phases can reference them.
  - `get( $attachment_id, $file_path ): ?string` — `null` on miss, the cached string (possibly empty) on hit. The `?string` distinction preserves empty-by-design vs not-extracted-yet.
  - `set( $attachment_id, $file_path, $text ): void` — defensive no-op on invalid IDs or unhashable files so caching cannot break the calling extraction path.
- **`wpdr_extract_text()`** (`includes/template-functions.php`) now routes through the cache. Order is explicit and traced:
  1. `attachment` post-type guard (refuse non-attachment IDs so we don't write meta to the wrong post)
  2. Readable-file guard (unreadable file returns `''` *without* invalidating any prior cached text)
  3. `Cache::get()` — return cached string on hit
  4. MIME lookup
  5. Registry dispatch
  6. `Cache::set()` — write the new text + hash
- **Tests** (`tests/class-test-wp-document-revisions-text-extractor-cache.php`) cover:
  - Cache class: miss returns null, set→get round-trip (including empty), hash mismatch returns null, unreadable file returns null, invalid attachment ID no-ops gracefully.
  - Integration: first call invokes extractor + writes cache, second call served from cache (counting fake proves the extractor is not re-invoked); file content change triggers re-extraction; isolated per attachment; empty extractions are still cached; non-attachment IDs refused; unreadable file does not wipe existing cache.

### Out of scope (deferred)

- **`_wpdr_extraction_failed` flag** distinguishing empty-by-design (scanned PDF, password-protected) from extractor-failed — **phase 7**. Phase 6 caches *every* result from the registry, including `''`, and invalidates only on content hash change.
- **Async scheduling** via `wp_schedule_single_event` — phase 7.
- **Global `WPDR_TEXT_EXTRACTION` constant + per-document opt-out** — phase 8.
- **WP-CLI backfill command** — phase 9.

## Test plan

- [ ] CI `code-quality` (phpcs, phpstan, audit) passes
- [ ] All phpunit matrices pass; new `Test_WP_Document_Revisions_Text_Extractor_Cache` green
- [ ] Existing Phase 1, 3b, 4 integration tests (which now go through caching) still green — each makes a single `wpdr_extract_text()` call per test, so caching is transparent to them.

Closes part of #514 (phase 6 of 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)