### PR TITLE
Phase 10: unified-diff helper between two cached extracted texts (#514)

### DIFF
--- a/includes/class-wp-document-revisions-text-diff.php
+++ b/includes/class-wp-document-revisions-text-diff.php
@@ -235,7 +235,11 @@ class WP_Document_Revisions_Text_Diff {
 	 */
 	private static function load_diff_engine(): void {
 		if ( ! class_exists( 'Text_Diff_Renderer' ) ) {
-			require_once ABSPATH . WPINC . '/wp-diff.php';
+			// Hard-coded 'wp-includes' rather than the WPINC constant
+			// because phpstan-wordpress does not stub WPINC and this
+			// directory name is part of WordPress's stable public
+			// layout — it has not changed since 2.5 and is unlikely to.
+			require_once ABSPATH . 'wp-includes/wp-diff.php';
 		}
 		if ( ! class_exists( 'WP_Document_Revisions_Unified_Diff_Renderer' ) ) {
 			require_once __DIR__ . '/class-wp-document-revisions-unified-diff-renderer.php';

--- a/includes/class-wp-document-revisions-text-diff.php
+++ b/includes/class-wp-document-revisions-text-diff.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Unified-diff helper between two cached extracted texts.
+ *
+ * Wraps WordPress core's `Text_Diff` engine with a unified-format
+ * renderer (see {@see WP_Document_Revisions_Unified_Diff_Renderer}) and
+ * exposes two entry points:
+ *
+ * - {@see self::diff_text()}: diff two plain strings directly.
+ * - {@see self::diff_revisions()}: diff the cached extracted text of
+ *   two revision attachments (loaded via {@see wpdr_extract_text()}).
+ *
+ * Both methods return a structured array — `['status' => ..., 'diff' => ...]`
+ * — rather than a bare string, so callers (notably the upcoming phase
+ * 11 summary REST endpoint) can distinguish between an empty diff
+ * (text unchanged), a too-large diff (fall back to document-summary),
+ * and a missing extracted text on either side (also fall back to
+ * document-summary). The status vocabulary is:
+ *
+ *   'identical'         — old and new texts compare equal; diff is ''.
+ *   'ok'                — diff is non-empty and within the size cap.
+ *   'too_large'         — diff would exceed `max_chars`; diff is ''.
+ *   'old_text_missing'  — diff_revisions: wpdr_extract_text() returned
+ *                         empty for the old revision (no cached text or
+ *                         legitimately empty extraction). diff is ''.
+ *   'new_text_missing'  — same, for the new revision. diff is ''.
+ *
+ * Configurable via filters and per-call options:
+ *
+ *   'context_lines'  default 3, filter `wpdr_text_diff_context_lines`.
+ *   'max_chars'      default 50000, filter `wpdr_text_diff_max_chars`.
+ *
+ * The underlying `Text_Diff_Renderer` class is loaded lazily from
+ * `wp-diff.php` inside the public methods so plugin bootstrap pays
+ * nothing on requests that never call into the diff utility.
+ *
+ * Phase 10 of issue #514.
+ *
+ * @since 4.1.0
+ * @package WP_Document_Revisions
+ */
+
+// direct file access protection.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Unified-diff helper for cached extracted text.
+ */
+class WP_Document_Revisions_Text_Diff {
+
+	/**
+	 * Default leading and trailing context lines per hunk.
+	 *
+	 * Aligned with the issue's design ("~3 lines of context per hunk").
+	 * Overridable per-call via the `context_lines` option and globally
+	 * via the `wpdr_text_diff_context_lines` filter.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_CONTEXT_LINES = 3;
+
+	/**
+	 * Default size cap on the rendered diff, measured in characters.
+	 *
+	 * The phase-11 summary endpoint uses this to decide when a diff
+	 * is too large to be useful as model input — in those cases the
+	 * caller falls back to summarising the new document directly.
+	 * Filterable via `wpdr_text_diff_max_chars`; per-call override
+	 * via the `max_chars` option.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_MAX_CHARS = 50000;
+
+	/**
+	 * Compute a unified diff between two plain-text strings.
+	 *
+	 * Treats both inputs as line-oriented text (split on "\n") and
+	 * returns a result array as described in the class docblock.
+	 *
+	 * @param string                                   $old_text the original-side text.
+	 * @param string                                   $new_text the new-side text.
+	 * @param array{context_lines?: int, max_chars?: int} $opts   optional per-call overrides.
+	 * @return array{status: string, diff: string} result with `status` in
+	 *                                             {'identical','ok','too_large'} and
+	 *                                             `diff` populated only when status is 'ok'.
+	 */
+	public static function diff_text( string $old_text, string $new_text, array $opts = array() ): array {
+		if ( $old_text === $new_text ) {
+			return array(
+				'status' => 'identical',
+				'diff'   => '',
+			);
+		}
+
+		$context_lines = self::resolve_context_lines( $opts );
+		$max_chars     = self::resolve_max_chars( $opts );
+
+		self::load_diff_engine();
+
+		$diff = new Text_Diff(
+			'auto',
+			array(
+				explode( "\n", $old_text ),
+				explode( "\n", $new_text ),
+			)
+		);
+		$renderer = new WP_Document_Revisions_Unified_Diff_Renderer();
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$renderer->_leading_context_lines  = $context_lines;
+		$renderer->_trailing_context_lines = $context_lines;
+		// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+		$output = (string) $renderer->render( $diff );
+
+		// Text_Diff with two distinct inputs that happen to produce no
+		// hunks (shouldn't happen given the equality short-circuit
+		// above, but defensive) is treated as identical.
+		if ( '' === $output ) {
+			return array(
+				'status' => 'identical',
+				'diff'   => '',
+			);
+		}
+
+		if ( strlen( $output ) > $max_chars ) {
+			return array(
+				'status' => 'too_large',
+				'diff'   => '',
+			);
+		}
+
+		return array(
+			'status' => 'ok',
+			'diff'   => $output,
+		);
+	}
+
+	/**
+	 * Compute a unified diff between the cached extracted text of two
+	 * revision attachments.
+	 *
+	 * Loads text via {@see wpdr_extract_text()} for each side — this
+	 * runs the cache through the registered extractor on a miss, so
+	 * callers do not need to pre-warm the cache. When extraction for
+	 * either side returns the empty string the result reports
+	 * `old_text_missing` / `new_text_missing` rather than collapsing
+	 * to `identical`, so phase 11 can distinguish "scanned PDF on one
+	 * side" from "both sides have the same text."
+	 *
+	 * @param int                                      $old_revision_id attachment post ID of the original-side revision.
+	 * @param int                                      $new_revision_id attachment post ID of the new-side revision.
+	 * @param array{context_lines?: int, max_chars?: int} $opts            optional per-call overrides.
+	 * @return array{status: string, diff: string} result with `status` in
+	 *                                             {'identical','ok','too_large','old_text_missing','new_text_missing'}.
+	 */
+	public static function diff_revisions( int $old_revision_id, int $new_revision_id, array $opts = array() ): array {
+		$old_text = wpdr_extract_text( $old_revision_id );
+		if ( '' === $old_text ) {
+			return array(
+				'status' => 'old_text_missing',
+				'diff'   => '',
+			);
+		}
+
+		$new_text = wpdr_extract_text( $new_revision_id );
+		if ( '' === $new_text ) {
+			return array(
+				'status' => 'new_text_missing',
+				'diff'   => '',
+			);
+		}
+
+		return self::diff_text( $old_text, $new_text, $opts );
+	}
+
+	/**
+	 * Resolve the leading/trailing context-line count for a call.
+	 *
+	 * Precedence: per-call `context_lines` option ➜ filter ➜ class default.
+	 *
+	 * @param array<string, mixed> $opts per-call options.
+	 * @return int non-negative context-line count.
+	 */
+	private static function resolve_context_lines( array $opts ): int {
+		if ( isset( $opts['context_lines'] ) ) {
+			$value = (int) $opts['context_lines'];
+		} else {
+			/**
+			 * Filter the default number of context lines per hunk used
+			 * by the unified-diff helper.
+			 *
+			 * @since 4.1.0
+			 *
+			 * @param int $context_lines Default context-line count.
+			 */
+			$value = (int) apply_filters( 'wpdr_text_diff_context_lines', self::DEFAULT_CONTEXT_LINES );
+		}
+		return max( 0, $value );
+	}
+
+	/**
+	 * Resolve the maximum rendered-diff size for a call.
+	 *
+	 * Precedence: per-call `max_chars` option ➜ filter ➜ class default.
+	 *
+	 * @param array<string, mixed> $opts per-call options.
+	 * @return int non-negative maximum size in characters.
+	 */
+	private static function resolve_max_chars( array $opts ): int {
+		if ( isset( $opts['max_chars'] ) ) {
+			$value = (int) $opts['max_chars'];
+		} else {
+			/**
+			 * Filter the maximum rendered-diff size, in characters,
+			 * before the helper reports 'too_large'.
+			 *
+			 * @since 4.1.0
+			 *
+			 * @param int $max_chars Default size cap in characters.
+			 */
+			$value = (int) apply_filters( 'wpdr_text_diff_max_chars', self::DEFAULT_MAX_CHARS );
+		}
+		return max( 0, $value );
+	}
+
+	/**
+	 * Ensure the WP core diff engine and the unified renderer subclass
+	 * are loaded. Called from every public entry point and idempotent
+	 * via class_exists().
+	 *
+	 * @return void
+	 */
+	private static function load_diff_engine(): void {
+		if ( ! class_exists( 'Text_Diff_Renderer' ) ) {
+			require_once ABSPATH . WPINC . '/wp-diff.php';
+		}
+		if ( ! class_exists( 'WP_Document_Revisions_Unified_Diff_Renderer' ) ) {
+			require_once __DIR__ . '/class-wp-document-revisions-unified-diff-renderer.php';
+		}
+	}
+}

--- a/includes/class-wp-document-revisions-text-diff.php
+++ b/includes/class-wp-document-revisions-text-diff.php
@@ -80,9 +80,9 @@ class WP_Document_Revisions_Text_Diff {
 	 * Treats both inputs as line-oriented text (split on "\n") and
 	 * returns a result array as described in the class docblock.
 	 *
-	 * @param string                                   $old_text the original-side text.
-	 * @param string                                   $new_text the new-side text.
-	 * @param array{context_lines?: int, max_chars?: int} $opts   optional per-call overrides.
+	 * @param string                                      $old_text the original-side text.
+	 * @param string                                      $new_text the new-side text.
+	 * @param array{context_lines?: int, max_chars?: int} $opts     optional per-call overrides.
 	 * @return array{status: string, diff: string} result with `status` in
 	 *                                             {'identical','ok','too_large'} and
 	 *                                             `diff` populated only when status is 'ok'.
@@ -100,7 +100,7 @@ class WP_Document_Revisions_Text_Diff {
 
 		self::load_diff_engine();
 
-		$diff = new Text_Diff(
+		$diff     = new Text_Diff(
 			'auto',
 			array(
 				explode( "\n", $old_text ),
@@ -150,8 +150,8 @@ class WP_Document_Revisions_Text_Diff {
 	 * to `identical`, so phase 11 can distinguish "scanned PDF on one
 	 * side" from "both sides have the same text."
 	 *
-	 * @param int                                      $old_revision_id attachment post ID of the original-side revision.
-	 * @param int                                      $new_revision_id attachment post ID of the new-side revision.
+	 * @param int                                         $old_revision_id attachment post ID of the original-side revision.
+	 * @param int                                         $new_revision_id attachment post ID of the new-side revision.
 	 * @param array{context_lines?: int, max_chars?: int} $opts            optional per-call overrides.
 	 * @return array{status: string, diff: string} result with `status` in
 	 *                                             {'identical','ok','too_large','old_text_missing','new_text_missing'}.

--- a/includes/class-wp-document-revisions-unified-diff-renderer.php
+++ b/includes/class-wp-document-revisions-unified-diff-renderer.php
@@ -150,11 +150,17 @@ class WP_Document_Revisions_Unified_Diff_Renderer extends Text_Diff_Renderer {
 	 * Unified diff represents this as the deletions first, then the
 	 * additions — no inline "change" form like the table renderer uses.
 	 *
-	 * @param string[] $orig  original-side lines being replaced.
-	 * @param string[] $final new-side lines that replace them.
+	 * The parent's signature uses `$final` for the new-side lines; we
+	 * rename to `$replacement` here because phpcs treats `$final` as a
+	 * reserved-keyword parameter name (PHP allows it, but it shadows
+	 * the `final` class/method keyword and is harder to read). PHP
+	 * does not require parameter names to match across overrides.
+	 *
+	 * @param string[] $orig        original-side lines being replaced.
+	 * @param string[] $replacement new-side lines that replace them.
 	 * @return string deletions followed by additions.
 	 */
-	protected function _changed( $orig, $final ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
-		return $this->_deleted( $orig ) . $this->_added( $final );
+	protected function _changed( $orig, $replacement ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		return $this->_deleted( $orig ) . $this->_added( $replacement );
 	}
 }

--- a/includes/class-wp-document-revisions-unified-diff-renderer.php
+++ b/includes/class-wp-document-revisions-unified-diff-renderer.php
@@ -11,7 +11,7 @@
  *
  * The file is intentionally loaded lazily — it depends on
  * `Text_Diff_Renderer` being defined, which only happens after
- * `ABSPATH . WPINC . '/wp-diff.php'` has been required. The helper class
+ * `ABSPATH . 'wp-includes/wp-diff.php'` has been required. The helper class
  * loads both before instantiating the renderer; do not require this file
  * directly at plugin bootstrap.
  *
@@ -72,7 +72,7 @@ class WP_Document_Revisions_Unified_Diff_Renderer extends Text_Diff_Renderer {
 	 * @param int $ylen number of lines from the new side.
 	 * @return string the `@@ ... @@` header.
 	 */
-	protected function _blockHeader( $xbeg, $xlen, $ybeg, $ylen ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function _blockHeader( $xbeg, $xlen, $ybeg, $ylen ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		return sprintf( '@@ -%d,%d +%d,%d @@', $xbeg, $xlen, $ybeg, $ylen );
 	}
 
@@ -83,7 +83,7 @@ class WP_Document_Revisions_Unified_Diff_Renderer extends Text_Diff_Renderer {
 	 * @param string $header the header text returned by _blockHeader().
 	 * @return string header followed by a single newline.
 	 */
-	protected function _startBlock( $header ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function _startBlock( $header ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		return $header . "\n";
 	}
 
@@ -93,7 +93,7 @@ class WP_Document_Revisions_Unified_Diff_Renderer extends Text_Diff_Renderer {
 	 *
 	 * @return string empty string.
 	 */
-	protected function _endBlock() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function _endBlock() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		return '';
 	}
 
@@ -107,7 +107,7 @@ class WP_Document_Revisions_Unified_Diff_Renderer extends Text_Diff_Renderer {
 	 *                trailing newline so the next group starts on its
 	 *                own row.
 	 */
-	protected function _lines( $lines, $prefix = ' ' ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function _lines( $lines, $prefix = ' ' ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		if ( empty( $lines ) ) {
 			return '';
 		}
@@ -120,7 +120,7 @@ class WP_Document_Revisions_Unified_Diff_Renderer extends Text_Diff_Renderer {
 	 * @param string[] $lines lines added.
 	 * @return string lines prefixed with `+`.
 	 */
-	protected function _added( $lines ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function _added( $lines ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		return $this->_lines( $lines, '+' );
 	}
 
@@ -130,7 +130,7 @@ class WP_Document_Revisions_Unified_Diff_Renderer extends Text_Diff_Renderer {
 	 * @param string[] $lines lines deleted.
 	 * @return string lines prefixed with `-`.
 	 */
-	protected function _deleted( $lines ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function _deleted( $lines ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		return $this->_lines( $lines, '-' );
 	}
 
@@ -140,7 +140,7 @@ class WP_Document_Revisions_Unified_Diff_Renderer extends Text_Diff_Renderer {
 	 * @param string[] $lines unchanged lines.
 	 * @return string lines prefixed with a single space.
 	 */
-	protected function _context( $lines ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function _context( $lines ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		return $this->_lines( $lines, ' ' );
 	}
 
@@ -160,7 +160,7 @@ class WP_Document_Revisions_Unified_Diff_Renderer extends Text_Diff_Renderer {
 	 * @param string[] $replacement new-side lines that replace them.
 	 * @return string deletions followed by additions.
 	 */
-	protected function _changed( $orig, $replacement ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function _changed( $orig, $replacement ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		return $this->_deleted( $orig ) . $this->_added( $replacement );
 	}
 }

--- a/includes/class-wp-document-revisions-unified-diff-renderer.php
+++ b/includes/class-wp-document-revisions-unified-diff-renderer.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Unified-diff renderer for WordPress core's `Text_Diff`.
+ *
+ * WordPress ships `Text_Diff_Renderer` (the abstract base) and a
+ * `WP_Text_Diff_Renderer_Table` for the post-revisions UI, but does NOT
+ * include PEAR's `Text_Diff_Renderer_unified`. This file defines a small
+ * subclass of `Text_Diff_Renderer` that produces standard unified-diff
+ * output (`@@ -x,y +a,b @@` block headers; lines prefixed ` `, `+`, `-`)
+ * for use by {@see WP_Document_Revisions_Text_Diff}.
+ *
+ * The file is intentionally loaded lazily — it depends on
+ * `Text_Diff_Renderer` being defined, which only happens after
+ * `ABSPATH . WPINC . '/wp-diff.php'` has been required. The helper class
+ * loads both before instantiating the renderer; do not require this file
+ * directly at plugin bootstrap.
+ *
+ * Phase 10 of issue #514.
+ *
+ * @since 4.1.0
+ * @package WP_Document_Revisions
+ */
+
+// direct file access protection.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Sanity guard — this file MUST be required after wp-diff.php has loaded.
+if ( ! class_exists( 'Text_Diff_Renderer' ) ) {
+	return;
+}
+
+/**
+ * Render a `Text_Diff` as standard unified-diff text.
+ */
+class WP_Document_Revisions_Unified_Diff_Renderer extends Text_Diff_Renderer {
+
+	/**
+	 * Number of leading context lines per hunk.
+	 *
+	 * The base class defaults to 0 (WP overrides PEAR's 4). The issue's
+	 * design calls for ~3 lines of context so AI summaries can resolve
+	 * references like "Section 4.2" from surrounding text.
+	 *
+	 * phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
+	 *
+	 * @var int
+	 */
+	public $_leading_context_lines = 3;
+
+	/**
+	 * Number of trailing context lines per hunk.
+	 *
+	 * @var int
+	 */
+	public $_trailing_context_lines = 3;
+
+	// phpcs:enable PSR2.Classes.PropertyDeclaration.Underscore
+
+	/**
+	 * Render the unified-format hunk header.
+	 *
+	 * Mirrors the GNU diff `@@ -<xbeg>,<xlen> +<ybeg>,<ylen> @@` form.
+	 * When a side contributes a single line, GNU diff sometimes omits the
+	 * length suffix; we always emit the explicit `,N` form so downstream
+	 * parsers do not have to handle both shapes.
+	 *
+	 * @param int $xbeg first line of the original-side hunk (1-indexed).
+	 * @param int $xlen number of lines from the original side.
+	 * @param int $ybeg first line of the new-side hunk (1-indexed).
+	 * @param int $ylen number of lines from the new side.
+	 * @return string the `@@ ... @@` header.
+	 */
+	protected function _blockHeader( $xbeg, $xlen, $ybeg, $ylen ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		return sprintf( '@@ -%d,%d +%d,%d @@', $xbeg, $xlen, $ybeg, $ylen );
+	}
+
+	/**
+	 * Emit the header line plus a newline so subsequent line groups in
+	 * the same hunk start on their own row.
+	 *
+	 * @param string $header the header text returned by _blockHeader().
+	 * @return string header followed by a single newline.
+	 */
+	protected function _startBlock( $header ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		return $header . "\n";
+	}
+
+	/**
+	 * Emit nothing between hunks — line groups already terminate with
+	 * their own trailing newlines.
+	 *
+	 * @return string empty string.
+	 */
+	protected function _endBlock() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		return '';
+	}
+
+	/**
+	 * Prefix every line in a group and terminate the group with a
+	 * newline. Used by _added(), _deleted(), and _context() below.
+	 *
+	 * @param string[] $lines  individual diff lines (no trailing newlines).
+	 * @param string   $prefix one-character prefix to add to each line.
+	 * @return string the prefixed lines joined with newlines, plus a
+	 *                trailing newline so the next group starts on its
+	 *                own row.
+	 */
+	protected function _lines( $lines, $prefix = ' ' ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		if ( empty( $lines ) ) {
+			return '';
+		}
+		return $prefix . implode( "\n" . $prefix, $lines ) . "\n";
+	}
+
+	/**
+	 * Render added lines (lines present only in the new side).
+	 *
+	 * @param string[] $lines lines added.
+	 * @return string lines prefixed with `+`.
+	 */
+	protected function _added( $lines ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		return $this->_lines( $lines, '+' );
+	}
+
+	/**
+	 * Render deleted lines (lines present only in the original side).
+	 *
+	 * @param string[] $lines lines deleted.
+	 * @return string lines prefixed with `-`.
+	 */
+	protected function _deleted( $lines ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		return $this->_lines( $lines, '-' );
+	}
+
+	/**
+	 * Render context lines (lines unchanged between the two sides).
+	 *
+	 * @param string[] $lines unchanged lines.
+	 * @return string lines prefixed with a single space.
+	 */
+	protected function _context( $lines ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		return $this->_lines( $lines, ' ' );
+	}
+
+	/**
+	 * Render a changed hunk (some lines deleted, others added in their place).
+	 *
+	 * Unified diff represents this as the deletions first, then the
+	 * additions — no inline "change" form like the table renderer uses.
+	 *
+	 * @param string[] $orig  original-side lines being replaced.
+	 * @param string[] $final new-side lines that replace them.
+	 * @return string deletions followed by additions.
+	 */
+	protected function _changed( $orig, $final ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		return $this->_deleted( $orig ) . $this->_added( $final );
+	}
+}

--- a/tests/class-test-wp-document-revisions-text-diff.php
+++ b/tests/class-test-wp-document-revisions-text-diff.php
@@ -212,7 +212,7 @@ class Test_WP_Document_Revisions_Text_Diff extends Test_Common_WPDR {
 	 * standard unified-diff parsers expect.
 	 */
 	public function test_renderer_emits_canonical_block_header() {
-		require_once ABSPATH . WPINC . '/wp-diff.php';
+		require_once ABSPATH . 'wp-includes/wp-diff.php';
 		require_once __DIR__ . '/../includes/class-wp-document-revisions-unified-diff-renderer.php';
 
 		$diff     = new Text_Diff(

--- a/tests/class-test-wp-document-revisions-text-diff.php
+++ b/tests/class-test-wp-document-revisions-text-diff.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Tests for the unified-diff helper.
+ *
+ * Phase 10 of issue #514: verifies the status taxonomy, context-line and
+ * size-cap behaviour, the renderer's unified-format output (block header
+ * format, line prefixes), and the diff_revisions() loading path.
+ *
+ * @package WP_Document_Revisions
+ */
+
+/**
+ * Tests for WP_Document_Revisions_Text_Diff + the unified renderer.
+ */
+class Test_WP_Document_Revisions_Text_Diff extends Test_Common_WPDR {
+
+	/**
+	 * Load the counting-fake helper for diff_revisions tests.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once __DIR__ . '/class-wpdr-test-counting-text-extractor.php';
+	}
+
+	/**
+	 * Clear filters and cron so tests don't leak.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'wpdr_text_extractors' );
+		remove_all_filters( 'wpdr_text_diff_context_lines' );
+		remove_all_filters( 'wpdr_text_diff_max_chars' );
+		_set_cron_array( array() );
+		parent::tear_down();
+	}
+
+	/**
+	 * Register a counting fake extractor that returns the file contents.
+	 *
+	 * @return WPDR_Test_Counting_Text_Extractor the registered fake.
+	 */
+	private function register_counting_fake(): WPDR_Test_Counting_Text_Extractor {
+		$fake = new WPDR_Test_Counting_Text_Extractor( 'text/plain' );
+		add_filter(
+			'wpdr_text_extractors',
+			static function ( array $extractors ) use ( $fake ): array {
+				array_unshift( $extractors, $fake );
+				return $extractors;
+			}
+		);
+		return $fake;
+	}
+
+	/**
+	 * Create a document, attach a text file with the given content,
+	 * and return its revision attachment ID.
+	 *
+	 * @param string $body the file body to write before attaching.
+	 * @return int the attachment ID.
+	 */
+	private function create_text_attachment_with_body( string $body ): int {
+		// Use the suite's standard test_file fixture path, but overwrite
+		// the bytes so each fixture has the body we want diffed.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( self::$test_file, $body );
+
+		$doc_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Diff Test Document',
+				'post_type'   => 'document',
+				'post_status' => 'publish',
+			)
+		);
+		self::add_document_attachment( self::factory(), $doc_id, self::$test_file );
+
+		global $wpdr;
+		$revision = $wpdr->get_latest_revision( $doc_id );
+		return (int) $revision->post_content;
+	}
+
+	/**
+	 * Identical inputs report status `identical` with an empty diff.
+	 */
+	public function test_diff_text_identical_returns_identical_status() {
+		$result = WP_Document_Revisions_Text_Diff::diff_text( "alpha\nbeta\ngamma", "alpha\nbeta\ngamma" );
+
+		self::assertSame( 'identical', $result['status'] );
+		self::assertSame( '', $result['diff'] );
+	}
+
+	/**
+	 * Both-empty inputs are also `identical` (the empty diff case).
+	 */
+	public function test_diff_text_both_empty_returns_identical_status() {
+		$result = WP_Document_Revisions_Text_Diff::diff_text( '', '' );
+
+		self::assertSame( 'identical', $result['status'] );
+		self::assertSame( '', $result['diff'] );
+	}
+
+	/**
+	 * A small one-line edit returns status `ok` and a unified-format diff.
+	 */
+	public function test_diff_text_small_edit_returns_ok_with_unified_diff() {
+		$old    = "alpha\nbeta\ngamma";
+		$new    = "alpha\nBETA\ngamma";
+		$result = WP_Document_Revisions_Text_Diff::diff_text( $old, $new );
+
+		self::assertSame( 'ok', $result['status'] );
+		self::assertStringContainsString( '@@', $result['diff'], 'Unified diff should contain a block header' );
+		self::assertStringContainsString( "-beta", $result['diff'] );
+		self::assertStringContainsString( "+BETA", $result['diff'] );
+		// Context line "alpha" should appear (prefixed with a single space).
+		self::assertStringContainsString( " alpha", $result['diff'] );
+	}
+
+	/**
+	 * Wholesale rewrites that exceed `max_chars` report `too_large` and
+	 * suppress the diff (callers fall back to document-summary mode).
+	 */
+	public function test_diff_text_wholesale_rewrite_returns_too_large() {
+		// Build two distinct multi-line bodies large enough to blow a
+		// small per-call cap. 200 unique lines on each side ensures the
+		// rendered diff is well over 200 chars.
+		$old = '';
+		$new = '';
+		for ( $i = 0; $i < 200; $i++ ) {
+			$old .= "old line {$i}\n";
+			$new .= "new line {$i}\n";
+		}
+
+		$result = WP_Document_Revisions_Text_Diff::diff_text(
+			$old,
+			$new,
+			array( 'max_chars' => 200 )
+		);
+
+		self::assertSame( 'too_large', $result['status'] );
+		self::assertSame( '', $result['diff'], 'Too-large diff should be suppressed' );
+	}
+
+	/**
+	 * Empty old + non-empty new (file changed from empty/scan to text)
+	 * returns `ok` with each new-side line appearing as an addition.
+	 * Note that `explode("\n", "")` yields `[""]`, so the diff also
+	 * includes a deletion of that single empty line — that's expected
+	 * and not what this test is asserting against.
+	 */
+	public function test_diff_text_empty_to_content_renders_as_additions() {
+		$result = WP_Document_Revisions_Text_Diff::diff_text( '', "alpha\nbeta\ngamma" );
+
+		self::assertSame( 'ok', $result['status'] );
+		self::assertStringContainsString( '+alpha', $result['diff'] );
+		self::assertStringContainsString( '+beta', $result['diff'] );
+		self::assertStringContainsString( '+gamma', $result['diff'] );
+	}
+
+	/**
+	 * Non-empty old + empty new (file replaced with a scanned image
+	 * whose text extraction is empty) returns `ok` with a diff that's
+	 * all deletions.
+	 */
+	public function test_diff_text_content_to_empty_renders_as_pure_deletion() {
+		$result = WP_Document_Revisions_Text_Diff::diff_text( "alpha\nbeta\ngamma", '' );
+
+		self::assertSame( 'ok', $result['status'] );
+		self::assertStringContainsString( '-alpha', $result['diff'] );
+		self::assertStringContainsString( '-beta', $result['diff'] );
+		self::assertStringContainsString( '-gamma', $result['diff'] );
+	}
+
+	/**
+	 * Context-line option controls how much surrounding context the
+	 * renderer emits — verified by comparing a 1-line edit at the
+	 * middle of a long file with context=0 vs context=3.
+	 */
+	public function test_diff_text_context_lines_option_is_honoured() {
+		$old = "L1\nL2\nL3\nL4\nL5\nL6\nL7\nL8\nL9";
+		$new = "L1\nL2\nL3\nL4\nCHANGED\nL6\nL7\nL8\nL9";
+
+		$tight = WP_Document_Revisions_Text_Diff::diff_text( $old, $new, array( 'context_lines' => 0 ) );
+		$wide  = WP_Document_Revisions_Text_Diff::diff_text( $old, $new, array( 'context_lines' => 3 ) );
+
+		self::assertSame( 'ok', $tight['status'] );
+		self::assertSame( 'ok', $wide['status'] );
+		self::assertGreaterThan(
+			strlen( $tight['diff'] ),
+			strlen( $wide['diff'] ),
+			'Larger context should produce a larger rendered diff'
+		);
+		self::assertStringNotContainsString( ' L4', $tight['diff'], 'context=0 should omit surrounding L4' );
+		self::assertStringContainsString( ' L4', $wide['diff'], 'context=3 should include surrounding L4' );
+	}
+
+	/**
+	 * The `wpdr_text_diff_max_chars` filter shifts the cap globally.
+	 */
+	public function test_diff_text_max_chars_filter_changes_cap() {
+		add_filter(
+			'wpdr_text_diff_max_chars',
+			static function (): int {
+				return 5;
+			}
+		);
+
+		$result = WP_Document_Revisions_Text_Diff::diff_text( "a", "b" );
+
+		self::assertSame( 'too_large', $result['status'] );
+	}
+
+	/**
+	 * The renderer subclass emits the exact `@@ -x,y +a,b @@` form that
+	 * standard unified-diff parsers expect.
+	 */
+	public function test_renderer_emits_canonical_block_header() {
+		require_once ABSPATH . WPINC . '/wp-diff.php';
+		require_once __DIR__ . '/../includes/class-wp-document-revisions-unified-diff-renderer.php';
+
+		$diff     = new Text_Diff(
+			'auto',
+			array(
+				array( 'a', 'b', 'c' ),
+				array( 'a', 'X', 'c' ),
+			)
+		);
+		$renderer = new WP_Document_Revisions_Unified_Diff_Renderer();
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$renderer->_leading_context_lines  = 3;
+		$renderer->_trailing_context_lines = 3;
+		// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+		$output = (string) $renderer->render( $diff );
+
+		// With 3 lines of context on both sides of a single-line change
+		// inside a 3-line file, both old and new sides have length 3.
+		self::assertStringContainsString( '@@ -1,3 +1,3 @@', $output );
+		self::assertStringContainsString( "-b", $output );
+		self::assertStringContainsString( "+X", $output );
+	}
+
+	/**
+	 * `diff_revisions` returns `old_text_missing` when wpdr_extract_text
+	 * returns empty for the original side (e.g. scanned PDF, no cached
+	 * text). The new side is not consulted in that case.
+	 */
+	public function test_diff_revisions_reports_old_text_missing() {
+		// Counting fake configured to return '' simulates an extracted-
+		// empty file (scanned PDF, etc.).
+		$fake = new WPDR_Test_Counting_Text_Extractor( 'text/plain', '' );
+		add_filter(
+			'wpdr_text_extractors',
+			static function ( array $extractors ) use ( $fake ): array {
+				array_unshift( $extractors, $fake );
+				return $extractors;
+			}
+		);
+
+		$old = $this->create_text_attachment_with_body( 'whatever' );
+		$new = $this->create_text_attachment_with_body( 'also whatever' );
+
+		$result = WP_Document_Revisions_Text_Diff::diff_revisions( $old, $new );
+
+		self::assertSame( 'old_text_missing', $result['status'] );
+		self::assertSame( '', $result['diff'] );
+	}
+
+	/**
+	 * `diff_revisions` happy path: two attachments with distinct text
+	 * produce a unified diff.
+	 */
+	public function test_diff_revisions_produces_diff_between_two_attachments() {
+		$this->register_counting_fake();
+		$old = $this->create_text_attachment_with_body( "alpha\nbeta\ngamma" );
+		$new = $this->create_text_attachment_with_body( "alpha\nBETA\ngamma" );
+
+		$result = WP_Document_Revisions_Text_Diff::diff_revisions( $old, $new );
+
+		self::assertSame( 'ok', $result['status'] );
+		self::assertStringContainsString( '-beta', $result['diff'] );
+		self::assertStringContainsString( '+BETA', $result['diff'] );
+	}
+}

--- a/tests/class-test-wp-document-revisions-text-diff.php
+++ b/tests/class-test-wp-document-revisions-text-diff.php
@@ -107,10 +107,10 @@ class Test_WP_Document_Revisions_Text_Diff extends Test_Common_WPDR {
 
 		self::assertSame( 'ok', $result['status'] );
 		self::assertStringContainsString( '@@', $result['diff'], 'Unified diff should contain a block header' );
-		self::assertStringContainsString( "-beta", $result['diff'] );
-		self::assertStringContainsString( "+BETA", $result['diff'] );
+		self::assertStringContainsString( '-beta', $result['diff'] );
+		self::assertStringContainsString( '+BETA', $result['diff'] );
 		// Context line "alpha" should appear (prefixed with a single space).
-		self::assertStringContainsString( " alpha", $result['diff'] );
+		self::assertStringContainsString( ' alpha', $result['diff'] );
 	}
 
 	/**
@@ -202,7 +202,7 @@ class Test_WP_Document_Revisions_Text_Diff extends Test_Common_WPDR {
 			}
 		);
 
-		$result = WP_Document_Revisions_Text_Diff::diff_text( "a", "b" );
+		$result = WP_Document_Revisions_Text_Diff::diff_text( 'a', 'b' );
 
 		self::assertSame( 'too_large', $result['status'] );
 	}
@@ -233,8 +233,8 @@ class Test_WP_Document_Revisions_Text_Diff extends Test_Common_WPDR {
 		// With 3 lines of context on both sides of a single-line change
 		// inside a 3-line file, both old and new sides have length 3.
 		self::assertStringContainsString( '@@ -1,3 +1,3 @@', $output );
-		self::assertStringContainsString( "-b", $output );
-		self::assertStringContainsString( "+X", $output );
+		self::assertStringContainsString( '-b', $output );
+		self::assertStringContainsString( '+X', $output );
 	}
 
 	/**

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -99,6 +99,7 @@ require_once __DIR__ . '/includes/class-wp-document-revisions-text-extractor-reg
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-extractor-cache.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-extractor-scheduler.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-extraction-opt-out.php';
+require_once __DIR__ . '/includes/class-wp-document-revisions-text-diff.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-pdf-text-extractor.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-docx-text-extractor.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions.php';


### PR DESCRIPTION
## Summary

Lands the diff utility from phase 10 of #514 — a wrapper around WordPress core's `Text_Diff` engine that produces standard unified-diff output between two plain-text strings (or, by attachment ID, between two revisions' cached extracted text). This is the input shape that phase 11's AI-summary endpoint will send to the WP AI Client.

**Why a custom renderer:** WP ships `Text_Diff_Renderer` (abstract base) and `WP_Text_Diff_Renderer_Table` (HTML, for the post-revisions UI), but not PEAR's `Text_Diff_Renderer_unified`. This PR adds a minimal subclass that emits `@@ -x,y +a,b @@` block headers and ` ` / `+` / `-` line prefixes — small enough to maintain in-tree without adding a dependency.

**Status-based return:** `diff_text()` returns an array (`['status' => string, 'diff' => string]`) instead of a bare string so phase 11 can distinguish:

- `identical` — texts compare equal; produce a "no textual change" note rather than calling the model
- `ok` — diff present and within cap; send to the model
- `too_large` — diff exceeded `max_chars`; fall back to document-summary path
- `old_text_missing` / `new_text_missing` — `diff_revisions` only; extracted text was empty on that side (scanned PDF, etc.); fall back to document-summary path

**Configurable:** `context_lines` (default 3, filter `wpdr_text_diff_context_lines`) and `max_chars` (default 50000, filter `wpdr_text_diff_max_chars`), per-call overrides via options.

## Test plan

- [ ] CI green (PHPCS, PHPStan, PHPUnit across PHP/WP matrix)
- [ ] Tests cover the four cases the issue called for (identical, small edit, wholesale-rewrite-too-large, empty-text-but-changed) plus renderer block-header format, context-lines option, the max_chars filter, and `diff_revisions` happy + `old_text_missing` paths
- [ ] Manual smoke: in `wp shell`, create two attachments with distinct text, populate the cache, call `WP_Document_Revisions_Text_Diff::diff_revisions( $old, $new )`, inspect the returned diff
- [ ] Manual smoke: `add_filter( 'wpdr_text_diff_max_chars', fn() => 200 )`, run a `diff_revisions` against a real document pair and confirm large diffs return `too_large` status

Closes phase 10 of #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)