### PR TITLE
Phase 11: AI revision summaries — cron generator + REST endpoints (#514)

### DIFF
--- a/includes/class-wp-document-revisions-ai-summary-rest.php
+++ b/includes/class-wp-document-revisions-ai-summary-rest.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * REST endpoints for AI revision summaries.
+ *
+ * Exposes two routes under the `wpdr/v1` namespace:
+ *
+ *   GET  /wpdr/v1/documents/<doc_id>/revisions/<rev_id>/summary
+ *       Reads the cached AI summary. Returns a `status` field with one of
+ *       'ready', 'pending' (cron has not produced a summary yet), or
+ *       'unavailable' (AI was unreachable or the new revision has no
+ *       extractable text). Capability: `read_document` on the document.
+ *
+ *   POST /wpdr/v1/documents/<doc_id>/revisions/<rev_id>/summary/review
+ *       Marks (or un-marks) the cached summary as human-reviewed by the
+ *       current user. Capability: `edit_document` on the document.
+ *
+ * Generation itself is NOT exposed over REST — it runs on cron after
+ * extraction completes (see {@see WP_Document_Revisions_AI_Summary}).
+ * The capability mapping mirrors @NeilWJames's input on issue #514:
+ * reading a summary is gated like reading the document file, marking
+ * reviewed is gated like editing, and the per-revision diff record
+ * (which would require `read_document_revisions`) is intentionally
+ * not exposed in this phase.
+ *
+ * Phase 11 of issue #514.
+ *
+ * @since 4.1.0
+ * @package WP_Document_Revisions
+ */
+
+// direct file access protection.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST controller for the AI summary endpoints.
+ */
+class WP_Document_Revisions_AI_Summary_REST {
+
+	/**
+	 * REST namespace for the AI summary endpoints.
+	 *
+	 * @var string
+	 */
+	const ROUTE_NAMESPACE = 'wpdr/v1';
+
+	/**
+	 * Register the controller's routes with the REST API.
+	 *
+	 * @return void
+	 */
+	public static function init(): void {
+		add_action( 'rest_api_init', array( __CLASS__, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the read and review routes.
+	 *
+	 * @return void
+	 */
+	public static function register_routes(): void {
+		register_rest_route(
+			self::ROUTE_NAMESPACE,
+			'/documents/(?P<doc_id>\d+)/revisions/(?P<rev_id>\d+)/summary',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( __CLASS__, 'get_summary' ),
+				'permission_callback' => array( __CLASS__, 'can_read_summary' ),
+				'args'                => self::id_args(),
+			)
+		);
+		register_rest_route(
+			self::ROUTE_NAMESPACE,
+			'/documents/(?P<doc_id>\d+)/revisions/(?P<rev_id>\d+)/summary/review',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( __CLASS__, 'mark_reviewed' ),
+				'permission_callback' => array( __CLASS__, 'can_review_summary' ),
+				'args'                => array_merge(
+					self::id_args(),
+					array(
+						'reviewed' => array(
+							'type'        => 'boolean',
+							'default'     => true,
+							'description' => 'Pass false to un-mark a previously-reviewed summary.',
+						),
+					)
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission callback: caller must have `read_document` on the
+	 * claimed document, AND the claimed revision must actually be an
+	 * attachment of that document.
+	 *
+	 * @param WP_REST_Request $request incoming request.
+	 * @return true|WP_Error
+	 */
+	public static function can_read_summary( WP_REST_Request $request ) {
+		$ids = self::resolve_ids( $request );
+		if ( is_wp_error( $ids ) ) {
+			return $ids;
+		}
+		if ( ! current_user_can( 'read_document', $ids['doc_id'] ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Insufficient permission to read this document.', 'wp-document-revisions' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Permission callback: caller must have `edit_document` on the
+	 * claimed document, AND the claimed revision must actually be an
+	 * attachment of that document.
+	 *
+	 * @param WP_REST_Request $request incoming request.
+	 * @return true|WP_Error
+	 */
+	public static function can_review_summary( WP_REST_Request $request ) {
+		$ids = self::resolve_ids( $request );
+		if ( is_wp_error( $ids ) ) {
+			return $ids;
+		}
+		if ( ! current_user_can( 'edit_document', $ids['doc_id'] ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Insufficient permission to mark this summary reviewed.', 'wp-document-revisions' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * GET handler — return the cached summary as a JSON envelope.
+	 *
+	 * Response shape (always includes `status`):
+	 *
+	 *   { "status": "pending" }
+	 *   { "status": "unavailable", "kind": "unavailable" }
+	 *   {
+	 *     "status": "ready",
+	 *     "kind": "change"|"document"|"no_change",
+	 *     "summary": "...",
+	 *     "generated_at": 1234567890,
+	 *     "reviewed_by": 0,
+	 *     "reviewed_at": 0
+	 *   }
+	 *
+	 * @param WP_REST_Request $request incoming request.
+	 * @return WP_REST_Response
+	 */
+	public static function get_summary( WP_REST_Request $request ): WP_REST_Response {
+		$ids = self::resolve_ids( $request );
+		// resolve_ids() already validated for the permission callback;
+		// we know it's an array here, not a WP_Error.
+
+		$stored = WP_Document_Revisions_AI_Summary::get( $ids['rev_id'] );
+		if ( null === $stored ) {
+			return new WP_REST_Response( array( 'status' => 'pending' ), 200 );
+		}
+		if ( 'unavailable' === $stored['kind'] ) {
+			return new WP_REST_Response(
+				array(
+					'status' => 'unavailable',
+					'kind'   => 'unavailable',
+				),
+				200
+			);
+		}
+		return new WP_REST_Response(
+			array(
+				'status'       => 'ready',
+				'kind'         => $stored['kind'],
+				'summary'      => $stored['text'],
+				'generated_at' => $stored['generated_at'],
+				'reviewed_by'  => $stored['reviewed_by'],
+				'reviewed_at'  => $stored['reviewed_at'],
+			),
+			200
+		);
+	}
+
+	/**
+	 * POST review handler — mark (or un-mark) the cached summary as
+	 * reviewed by the current user.
+	 *
+	 * @param WP_REST_Request $request incoming request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public static function mark_reviewed( WP_REST_Request $request ) {
+		$ids = self::resolve_ids( $request );
+
+		$reviewed = (bool) $request->get_param( 'reviewed' );
+		$user_id  = $reviewed ? get_current_user_id() : 0;
+
+		$ok = WP_Document_Revisions_AI_Summary::set_reviewed( $ids['rev_id'], $user_id );
+		if ( ! $ok ) {
+			return new WP_Error(
+				'wpdr_summary_not_found',
+				__( 'No summary has been generated for this revision yet.', 'wp-document-revisions' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$stored = WP_Document_Revisions_AI_Summary::get( $ids['rev_id'] );
+		return new WP_REST_Response(
+			array(
+				'reviewed_by' => null === $stored ? 0 : (int) $stored['reviewed_by'],
+				'reviewed_at' => null === $stored ? 0 : (int) $stored['reviewed_at'],
+			),
+			200
+		);
+	}
+
+	/**
+	 * Validate that the claimed revision is actually an attachment
+	 * whose parent is the claimed document. Returns an associative
+	 * array of `{doc_id, rev_id}` on success or a WP_Error on
+	 * mismatch — surfaced from permission callbacks as a 404 so the
+	 * caller cannot probe for the existence of arbitrary documents
+	 * or attachments via the response shape.
+	 *
+	 * @param WP_REST_Request $request incoming request.
+	 * @return array{doc_id: int, rev_id: int}|WP_Error
+	 */
+	private static function resolve_ids( WP_REST_Request $request ) {
+		$doc_id = (int) $request->get_param( 'doc_id' );
+		$rev_id = (int) $request->get_param( 'rev_id' );
+		if ( $doc_id <= 0 || $rev_id <= 0 ) {
+			return new WP_Error( 'rest_not_found', '', array( 'status' => 404 ) );
+		}
+		if ( 'document' !== get_post_type( $doc_id ) ) {
+			return new WP_Error( 'rest_not_found', '', array( 'status' => 404 ) );
+		}
+		if ( 'attachment' !== get_post_type( $rev_id ) ) {
+			return new WP_Error( 'rest_not_found', '', array( 'status' => 404 ) );
+		}
+		if ( (int) wp_get_post_parent_id( $rev_id ) !== $doc_id ) {
+			return new WP_Error( 'rest_not_found', '', array( 'status' => 404 ) );
+		}
+		return array(
+			'doc_id' => $doc_id,
+			'rev_id' => $rev_id,
+		);
+	}
+
+	/**
+	 * Shared `args` schema fragment for the `doc_id` / `rev_id` path
+	 * parameters used by both routes.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	private static function id_args(): array {
+		return array(
+			'doc_id' => array(
+				'type'        => 'integer',
+				'required'    => true,
+				'description' => 'Document post ID.',
+			),
+			'rev_id' => array(
+				'type'        => 'integer',
+				'required'    => true,
+				'description' => 'Revision attachment post ID.',
+			),
+		);
+	}
+}

--- a/includes/class-wp-document-revisions-ai-summary.php
+++ b/includes/class-wp-document-revisions-ai-summary.php
@@ -1,0 +1,560 @@
+<?php
+/**
+ * AI-generated revision summaries.
+ *
+ * After text extraction completes on a revision attachment (signalled by
+ * the `wpdr_text_extracted` action fired from {@see
+ * WP_Document_Revisions_Text_Extractor_Cache::set()}), this class queues
+ * an async cron event that:
+ *
+ *   1. Finds the immediately prior revision of the same document.
+ *   2. Computes the unified diff via {@see WP_Document_Revisions_Text_Diff}.
+ *   3. Routes the diff status to a summary "kind":
+ *        ok                → 'change'      (send the diff to the model)
+ *        identical         → 'no_change'   (no AI call, fixed message)
+ *        too_large         → 'document'    (summarise the new text directly)
+ *        old_text_missing  → 'document'    (no prior text to diff against)
+ *        new_text_missing  → 'unavailable' (cannot summarise yet)
+ *      The same mapping applies when no prior revision exists at all
+ *      (initial upload → 'document').
+ *   4. Calls the WordPress 7.0 AI Client via {@see wp_ai_client_prompt()},
+ *      with a filterable system prompt, and stores the result.
+ *
+ * The result lives in post meta on the new revision attachment:
+ *
+ *   _wpdr_ai_summary_text          Cached summary string.
+ *   _wpdr_ai_summary_kind          One of 'change'|'document'|'no_change'|'unavailable'.
+ *   _wpdr_ai_summary_input_hash    SHA-256 of the exact input sent to the
+ *                                  model (the diff for 'change', the new
+ *                                  extracted text for 'document'). Used as
+ *                                  the cache key so re-running the cron
+ *                                  against unchanged inputs is a no-op.
+ *   _wpdr_ai_summary_generated_at  Unix timestamp of generation.
+ *   _wpdr_ai_summary_reviewed_by   User ID who marked the summary reviewed
+ *                                  via the REST endpoint, or 0.
+ *   _wpdr_ai_summary_reviewed_at   Unix timestamp of review, or 0.
+ *
+ * Sites without WordPress 7.0 (or with `WP_AI_SUPPORT` set to false)
+ * skip silently — the cron event runs but stores nothing, the REST
+ * endpoint reports status `unavailable`. Tests inject a generator via
+ * the `wpdr_ai_summary_generator` filter so the rest of the pipeline
+ * is exercised without a live AI provider.
+ *
+ * Phase 11 of issue #514.
+ *
+ * @since 4.1.0
+ * @package WP_Document_Revisions
+ */
+
+// direct file access protection.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Cron-driven AI summary generator + storage layer for revision attachments.
+ */
+class WP_Document_Revisions_AI_Summary {
+
+	/**
+	 * Post-meta key holding the cached summary text.
+	 *
+	 * @var string
+	 */
+	const META_KEY_TEXT = '_wpdr_ai_summary_text';
+
+	/**
+	 * Post-meta key holding the summary kind.
+	 *
+	 * @var string
+	 */
+	const META_KEY_KIND = '_wpdr_ai_summary_kind';
+
+	/**
+	 * Post-meta key holding the SHA-256 of the input the model was asked
+	 * to summarise. Re-running generation when this hash matches the
+	 * current inputs is a no-op.
+	 *
+	 * @var string
+	 */
+	const META_KEY_INPUT_HASH = '_wpdr_ai_summary_input_hash';
+
+	/**
+	 * Post-meta key holding the Unix timestamp of generation.
+	 *
+	 * @var string
+	 */
+	const META_KEY_GENERATED_AT = '_wpdr_ai_summary_generated_at';
+
+	/**
+	 * Post-meta key holding the user ID who marked the summary reviewed.
+	 *
+	 * @var string
+	 */
+	const META_KEY_REVIEWED_BY = '_wpdr_ai_summary_reviewed_by';
+
+	/**
+	 * Post-meta key holding the Unix timestamp of review.
+	 *
+	 * @var string
+	 */
+	const META_KEY_REVIEWED_AT = '_wpdr_ai_summary_reviewed_at';
+
+	/**
+	 * Cron action name fired to generate a summary for one attachment.
+	 *
+	 * @var string
+	 */
+	const CRON_ACTION = 'wpdr_generate_ai_summary';
+
+	/**
+	 * Default delay between the `wpdr_text_extracted` action and the
+	 * summary cron event. Mirrors phase 7's ~10-second pattern so the
+	 * request that triggered extraction has time to settle.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_DELAY = 10;
+
+	/**
+	 * Default per-call timeout, in seconds, applied via set_time_limit()
+	 * inside the cron handler. The AI provider may itself enforce a
+	 * shorter timeout; this is the local upper bound.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_TIMEOUT = 60;
+
+	/**
+	 * Fixed string stored as the summary when the diff was empty
+	 * (file changed but extracted text did not). No AI call required.
+	 *
+	 * @var string
+	 */
+	const NO_CHANGE_MESSAGE = 'No textual change between this revision and the prior one.';
+
+	/**
+	 * Register the cache-trigger hook and cron handler.
+	 *
+	 * @return void
+	 */
+	public static function init(): void {
+		add_action( 'wpdr_text_extracted', array( __CLASS__, 'maybe_schedule' ) );
+		add_action( self::CRON_ACTION, array( __CLASS__, 'run' ) );
+	}
+
+	/**
+	 * Whether the WordPress 7.0 AI Client is available for the current
+	 * site. Honours the `WP_AI_SUPPORT` constant (false disables AI use
+	 * even if the client is loaded) and the function-existence check
+	 * (the AI Client ships in WP 7.0; older WordPress does not have it).
+	 *
+	 * @return bool true when summaries can be generated via the AI Client.
+	 */
+	public static function is_ai_available(): bool {
+		if ( defined( 'WP_AI_SUPPORT' ) && false === WP_AI_SUPPORT ) {
+			return false;
+		}
+		/**
+		 * Filter the availability check so tests (and sites running an
+		 * alternative provider via the `wpdr_ai_summary_generator`
+		 * filter) can force-enable the pipeline without WP 7.0.
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param bool|null $available Force true/false to override; null
+		 *                             defers to the default check.
+		 */
+		$forced = apply_filters( 'wpdr_ai_summary_available', null );
+		if ( null !== $forced ) {
+			return (bool) $forced;
+		}
+		return function_exists( 'wp_ai_client_prompt' );
+	}
+
+	/**
+	 * Hook callback for `wpdr_text_extracted`. Queues a single cron
+	 * event for the attachment if one is not already scheduled.
+	 *
+	 * @param int $attachment_id ID of the attachment whose text just landed in the cache.
+	 * @return void
+	 */
+	public static function maybe_schedule( int $attachment_id ): void {
+		if ( $attachment_id <= 0 || 'attachment' !== get_post_type( $attachment_id ) ) {
+			return;
+		}
+
+		$parent_id = (int) wp_get_post_parent_id( $attachment_id );
+		if ( $parent_id <= 0 || 'document' !== get_post_type( $parent_id ) ) {
+			return;
+		}
+
+		if ( WP_Document_Revisions_Text_Extraction_Opt_Out::is_disabled_for_document( $parent_id ) ) {
+			return;
+		}
+
+		$args = array( $attachment_id );
+		if ( false !== wp_next_scheduled( self::CRON_ACTION, $args ) ) {
+			return;
+		}
+
+		/**
+		 * Filter the delay between text extraction and summary generation.
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param int $delay         Seconds to wait before running the summary cron.
+		 * @param int $attachment_id Attachment being scheduled.
+		 */
+		$delay = (int) apply_filters( 'wpdr_ai_summary_delay', self::DEFAULT_DELAY, $attachment_id );
+		if ( $delay < 0 ) {
+			$delay = 0;
+		}
+
+		wp_schedule_single_event( time() + $delay, self::CRON_ACTION, $args );
+	}
+
+	/**
+	 * Cron handler: generate (or refresh) the AI summary for one attachment.
+	 *
+	 * Idempotent within a generation: re-running against an attachment
+	 * whose stored input_hash already matches the current inputs is a
+	 * no-op. Replacing the file (which changes extraction → changes the
+	 * diff → changes the input hash) cleanly invalidates the cached
+	 * summary on the next cron pass.
+	 *
+	 * @param int $attachment_id ID of the new-side revision attachment.
+	 * @return void
+	 */
+	public static function run( int $attachment_id ): void {
+		if ( $attachment_id <= 0 || 'attachment' !== get_post_type( $attachment_id ) ) {
+			return;
+		}
+
+		$parent_id = (int) wp_get_post_parent_id( $attachment_id );
+		if ( $parent_id <= 0 || 'document' !== get_post_type( $parent_id ) ) {
+			return;
+		}
+
+		if ( WP_Document_Revisions_Text_Extraction_Opt_Out::is_disabled_for_document( $parent_id ) ) {
+			return;
+		}
+
+		$plan = self::plan_for( $attachment_id, $parent_id );
+		if ( null === $plan ) {
+			return;
+		}
+
+		$current_input_hash = '' === $plan['input'] ? '' : hash( 'sha256', $plan['input'] );
+		$stored_input_hash  = (string) get_post_meta( $attachment_id, self::META_KEY_INPUT_HASH, true );
+		$stored_kind        = (string) get_post_meta( $attachment_id, self::META_KEY_KIND, true );
+
+		// Same inputs + same kind → cached summary already accurate.
+		if ( '' !== $stored_kind && $stored_kind === $plan['kind'] && $stored_input_hash === $current_input_hash ) {
+			return;
+		}
+
+		// No AI call needed for these kinds — record a fixed result.
+		if ( 'no_change' === $plan['kind'] ) {
+			self::store( $attachment_id, $plan['kind'], self::NO_CHANGE_MESSAGE, $current_input_hash );
+			return;
+		}
+		if ( 'unavailable' === $plan['kind'] ) {
+			self::store( $attachment_id, $plan['kind'], '', $current_input_hash );
+			return;
+		}
+
+		if ( ! self::is_ai_available() ) {
+			// Defer: do not store an empty summary so a later run (after
+			// the site upgrades to WP 7.0 / enables WP_AI_SUPPORT) will
+			// generate properly.
+			return;
+		}
+
+		$timeout = (int) apply_filters( 'wpdr_ai_summary_timeout', self::DEFAULT_TIMEOUT, $attachment_id );
+		if ( $timeout > 0 ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.PHP.IniSet.Risky
+			@set_time_limit( $timeout );
+		}
+
+		$prompt = self::compose_prompt( $plan['kind'], $plan['input'], $attachment_id );
+		$text   = self::call_ai( $prompt );
+		if ( null === $text ) {
+			return;
+		}
+
+		self::store( $attachment_id, $plan['kind'], $text, $current_input_hash );
+	}
+
+	/**
+	 * Decide what to summarise for an attachment and produce the input
+	 * string that should be hashed + (optionally) sent to the model.
+	 *
+	 * @param int $attachment_id new-side revision attachment.
+	 * @param int $parent_id     parent document post ID.
+	 * @return array{kind: string, input: string}|null plan, or null on hard failure.
+	 */
+	private static function plan_for( int $attachment_id, int $parent_id ): ?array {
+		$prior_id = self::prior_revision_id( $attachment_id, $parent_id );
+
+		// No prior revision (initial upload) → document summary path.
+		if ( 0 === $prior_id ) {
+			$new_text = wpdr_extract_text( $attachment_id );
+			if ( '' === $new_text ) {
+				return array(
+					'kind'  => 'unavailable',
+					'input' => '',
+				);
+			}
+			return array(
+				'kind'  => 'document',
+				'input' => $new_text,
+			);
+		}
+
+		$result = WP_Document_Revisions_Text_Diff::diff_revisions( $prior_id, $attachment_id );
+
+		switch ( $result['status'] ) {
+			case 'ok':
+				return array(
+					'kind'  => 'change',
+					'input' => $result['diff'],
+				);
+			case 'identical':
+				return array(
+					'kind'  => 'no_change',
+					'input' => '',
+				);
+			case 'too_large':
+			case 'old_text_missing':
+				// Either side has no useful text-difference signal:
+				// fall back to summarising the new side directly.
+				$new_text = wpdr_extract_text( $attachment_id );
+				if ( '' === $new_text ) {
+					return array(
+						'kind'  => 'unavailable',
+						'input' => '',
+					);
+				}
+				return array(
+					'kind'  => 'document',
+					'input' => $new_text,
+				);
+			case 'new_text_missing':
+				// New side has no extracted text yet — defer until it does.
+				return array(
+					'kind'  => 'unavailable',
+					'input' => '',
+				);
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Find the revision attachment that immediately precedes a given
+	 * revision attachment within the same document.
+	 *
+	 * Returns 0 when the passed attachment is the document's first
+	 * revision (initial upload).
+	 *
+	 * Sorts attachments by ID descending before walking so the result
+	 * is independent of whatever order `$wpdr->get_attachments()`
+	 * returns — attachment IDs are strictly increasing per WordPress's
+	 * post_id sequence, so "older" reliably means "lower ID."
+	 *
+	 * @param int $attachment_id new-side revision attachment.
+	 * @param int $document_id   parent document post ID.
+	 * @return int prior attachment ID, or 0 when no prior revision exists.
+	 */
+	public static function prior_revision_id( int $attachment_id, int $document_id ): int {
+		global $wpdr;
+		if ( ! $wpdr || ! method_exists( $wpdr, 'get_attachments' ) ) {
+			return 0;
+		}
+		$attachments = $wpdr->get_attachments( $document_id );
+		if ( ! is_array( $attachments ) ) {
+			return 0;
+		}
+		$ids = array();
+		foreach ( $attachments as $attachment ) {
+			$id = isset( $attachment->ID ) ? (int) $attachment->ID : 0;
+			if ( $id > 0 ) {
+				$ids[] = $id;
+			}
+		}
+		rsort( $ids );
+
+		$found = false;
+		foreach ( $ids as $id ) {
+			if ( $found ) {
+				return $id;
+			}
+			if ( $id === $attachment_id ) {
+				$found = true;
+			}
+		}
+		return 0;
+	}
+
+	/**
+	 * Compose the prompt text to send to the AI Client. The default
+	 * templates are filterable via `wpdr_ai_summary_prompt` so sites
+	 * can tune tone, length, or language without touching code.
+	 *
+	 * The filter intentionally does NOT receive the input text — the
+	 * input is what the prompt operates on, not part of the prompt
+	 * template. Filters that prepend rather than replace are a common
+	 * source of subtle bugs, so we pass `kind` and the revision ID and
+	 * let the filter decide which sprintf format string to return.
+	 *
+	 * @param string $kind          one of 'change' or 'document'.
+	 * @param string $input         the diff or text to be summarised.
+	 * @param int    $attachment_id the revision attachment being summarised.
+	 * @return string the assembled prompt.
+	 */
+	public static function compose_prompt( string $kind, string $input, int $attachment_id ): string {
+		if ( 'change' === $kind ) {
+			$default = 'You are summarising a change to a document. Given the following unified diff, write a 1–3 sentence summary describing what changed. Focus on substantive content changes, not formatting or whitespace, and do not narrate the diff format itself — describe the change as it would appear to a reader of the document.';
+		} else {
+			$default = 'You are summarising a document. Given the following text, write a 1–3 sentence summary describing what the document is about and its key topics.';
+		}
+
+		/**
+		 * Filter the system prompt template used for AI summaries.
+		 *
+		 * The filter receives the kind and the revision ID but NOT the
+		 * input text — the prompt template is the instruction; the
+		 * input is concatenated after it. Return a plain string.
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param string $template      Default prompt for this kind.
+		 * @param string $kind          'change' or 'document'.
+		 * @param int    $attachment_id Revision attachment being summarised.
+		 */
+		$template = (string) apply_filters( 'wpdr_ai_summary_prompt', $default, $kind, $attachment_id );
+
+		return $template . "\n\n" . $input;
+	}
+
+	/**
+	 * Invoke the AI Client (or a test-injected generator) for the given
+	 * prompt. Returns null on any failure so the caller can short-circuit.
+	 *
+	 * @param string $prompt fully-assembled prompt.
+	 * @return string|null generated text, or null on failure.
+	 */
+	private static function call_ai( string $prompt ): ?string {
+		/**
+		 * Allow tests and sites running an alternative AI provider to
+		 * intercept the call. Return a string to short-circuit (used by
+		 * the test suite); return null to defer to the real provider.
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param string|null $result Forced result, or null to defer.
+		 * @param string      $prompt The composed prompt.
+		 */
+		$injected = apply_filters( 'wpdr_ai_summary_generator', null, $prompt );
+		if ( is_string( $injected ) ) {
+			return $injected;
+		}
+
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+		$response = wp_ai_client_prompt( $prompt )->generate_text();
+		if ( is_wp_error( $response ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( 'WP Document Revisions: AI summary generation failed: ' . $response->get_error_message() );
+			return null;
+		}
+		if ( ! is_string( $response ) || '' === trim( $response ) ) {
+			return null;
+		}
+		return trim( $response );
+	}
+
+	/**
+	 * Persist a summary result. Every call clears the reviewed-by/at
+	 * meta on the principle that a freshly-stored summary is by
+	 * definition not yet reviewed — and `run()` only invokes this
+	 * function when the inputs have actually changed (a same-inputs
+	 * regeneration is short-circuited earlier).
+	 *
+	 * @param int    $attachment_id revision attachment whose summary we are storing.
+	 * @param string $kind          one of 'change'|'document'|'no_change'|'unavailable'.
+	 * @param string $text          the cached summary string ('' for 'unavailable').
+	 * @param string $input_hash    SHA-256 of the input sent to the model ('' when not applicable).
+	 * @return void
+	 */
+	public static function store( int $attachment_id, string $kind, string $text, string $input_hash ): void {
+		if ( $attachment_id <= 0 ) {
+			return;
+		}
+		update_post_meta( $attachment_id, self::META_KEY_TEXT, $text );
+		update_post_meta( $attachment_id, self::META_KEY_KIND, $kind );
+		update_post_meta( $attachment_id, self::META_KEY_INPUT_HASH, $input_hash );
+		update_post_meta( $attachment_id, self::META_KEY_GENERATED_AT, time() );
+		// New summary supersedes any prior review — the previous review
+		// applied to text that no longer reflects the current revision.
+		delete_post_meta( $attachment_id, self::META_KEY_REVIEWED_BY );
+		delete_post_meta( $attachment_id, self::META_KEY_REVIEWED_AT );
+	}
+
+	/**
+	 * Mark a summary as human-reviewed by the current user. Returns
+	 * false when the attachment has no stored summary to review.
+	 *
+	 * @param int $attachment_id revision attachment whose summary is being reviewed.
+	 * @param int $user_id       user marking the review (0 to unmark).
+	 * @return bool true on success.
+	 */
+	public static function set_reviewed( int $attachment_id, int $user_id ): bool {
+		if ( $attachment_id <= 0 ) {
+			return false;
+		}
+		$kind = (string) get_post_meta( $attachment_id, self::META_KEY_KIND, true );
+		if ( '' === $kind ) {
+			return false;
+		}
+		if ( $user_id > 0 ) {
+			update_post_meta( $attachment_id, self::META_KEY_REVIEWED_BY, $user_id );
+			update_post_meta( $attachment_id, self::META_KEY_REVIEWED_AT, time() );
+		} else {
+			delete_post_meta( $attachment_id, self::META_KEY_REVIEWED_BY );
+			delete_post_meta( $attachment_id, self::META_KEY_REVIEWED_AT );
+		}
+		return true;
+	}
+
+	/**
+	 * Read the stored summary record for a revision attachment.
+	 *
+	 * Returns null when nothing has been stored yet (the cron event has
+	 * not run, or has not yet completed). Callers use this to drive the
+	 * REST `pending` vs `ready` distinction.
+	 *
+	 * @param int $attachment_id revision attachment ID.
+	 * @return array{text: string, kind: string, generated_at: int, reviewed_by: int, reviewed_at: int}|null
+	 */
+	public static function get( int $attachment_id ): ?array {
+		if ( $attachment_id <= 0 ) {
+			return null;
+		}
+		$kind = (string) get_post_meta( $attachment_id, self::META_KEY_KIND, true );
+		if ( '' === $kind ) {
+			return null;
+		}
+		return array(
+			'text'         => (string) get_post_meta( $attachment_id, self::META_KEY_TEXT, true ),
+			'kind'         => $kind,
+			'generated_at' => (int) get_post_meta( $attachment_id, self::META_KEY_GENERATED_AT, true ),
+			'reviewed_by'  => (int) get_post_meta( $attachment_id, self::META_KEY_REVIEWED_BY, true ),
+			'reviewed_at'  => (int) get_post_meta( $attachment_id, self::META_KEY_REVIEWED_AT, true ),
+		);
+	}
+}

--- a/includes/class-wp-document-revisions-text-extractor-cache.php
+++ b/includes/class-wp-document-revisions-text-extractor-cache.php
@@ -141,6 +141,23 @@ class WP_Document_Revisions_Text_Extractor_Cache {
 		// for this file, so the async scheduler is free to run again if the
 		// file is later replaced.
 		delete_post_meta( $attachment_id, self::META_KEY_FAILED_HASH );
+
+		/**
+		 * Fires after extracted text is successfully cached for a
+		 * revision attachment.
+		 *
+		 * Phase 11's AI-summary scheduler listens for this so it can
+		 * queue a summary cron event once extracted text is available.
+		 * Third parties can hook this for downstream consumers
+		 * (search indexing, embeddings, etc.) without monkey-patching
+		 * the cache class.
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param int $attachment_id ID of the revision attachment whose
+		 *                           extracted text was just cached.
+		 */
+		do_action( 'wpdr_text_extracted', $attachment_id );
 	}
 
 	/**

--- a/tests/class-test-wp-document-revisions-ai-summary-rest.php
+++ b/tests/class-test-wp-document-revisions-ai-summary-rest.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Tests for the AI summary REST endpoints.
+ *
+ * Phase 11 of issue #514: verifies the read endpoint's status taxonomy
+ * (pending / ready / unavailable), the review endpoint's write path,
+ * and Neil's capability mapping — `read_document` for read,
+ * `edit_document` for marking reviewed, 404 (not 401) when the claimed
+ * revision does not belong to the claimed document so the response
+ * does not let an unauthorised caller probe for which documents own
+ * which attachments.
+ *
+ * @package WP_Document_Revisions
+ */
+
+/**
+ * Tests for WP_Document_Revisions_AI_Summary_REST.
+ */
+class Test_WP_Document_Revisions_AI_Summary_REST extends Test_Common_WPDR {
+
+	/**
+	 * REST server, re-initialised per test so route registration is
+	 * deterministic.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Stand up a fresh REST server and register routes for each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Tear down the REST server reference so it does not leak into
+	 * other tests.
+	 */
+	public function tear_down() {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a document with one attached revision and return both IDs.
+	 *
+	 * @return array{0:int,1:int} [ document_id, attachment_id ].
+	 */
+	private function create_document_with_attachment(): array {
+		$doc_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'AI Summary REST Test',
+				'post_type'   => 'document',
+				'post_status' => 'publish',
+			)
+		);
+		self::add_document_attachment( self::factory(), $doc_id, self::$test_file );
+
+		global $wpdr;
+		$revision = $wpdr->get_latest_revision( $doc_id );
+		return array( (int) $doc_id, (int) $revision->post_content );
+	}
+
+	/**
+	 * Build a relative REST route for the summary endpoint.
+	 *
+	 * @param int    $doc_id document post ID.
+	 * @param int    $rev_id revision attachment ID.
+	 * @param string $suffix optional suffix (e.g. '/review').
+	 * @return string the full route path.
+	 */
+	private function summary_route( int $doc_id, int $rev_id, string $suffix = '' ): string {
+		return sprintf( '/wpdr/v1/documents/%d/revisions/%d/summary%s', $doc_id, $rev_id, $suffix );
+	}
+
+	/**
+	 * GET returns `pending` when no summary has been stored yet.
+	 */
+	public function test_get_returns_pending_when_no_summary_stored() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		list( $doc_id, $attach_id ) = $this->create_document_with_attachment();
+
+		$response = $this->server->dispatch(
+			new WP_REST_Request( 'GET', $this->summary_route( $doc_id, $attach_id ) )
+		);
+
+		self::assertSame( 200, $response->get_status() );
+		self::assertSame( array( 'status' => 'pending' ), $response->get_data() );
+	}
+
+	/**
+	 * GET returns the stored summary as `ready` once meta exists.
+	 */
+	public function test_get_returns_ready_with_stored_summary() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		list( $doc_id, $attach_id ) = $this->create_document_with_attachment();
+		WP_Document_Revisions_AI_Summary::store( $attach_id, 'change', 'Section 4.2 updated.', 'input-hash' );
+
+		$response = $this->server->dispatch(
+			new WP_REST_Request( 'GET', $this->summary_route( $doc_id, $attach_id ) )
+		);
+
+		self::assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		self::assertSame( 'ready', $data['status'] );
+		self::assertSame( 'change', $data['kind'] );
+		self::assertSame( 'Section 4.2 updated.', $data['summary'] );
+		self::assertGreaterThan( 0, $data['generated_at'] );
+	}
+
+	/**
+	 * GET reports `unavailable` when the cron stored an unavailable
+	 * record (e.g. AI was unreachable / no extractable text).
+	 */
+	public function test_get_returns_unavailable_when_kind_is_unavailable() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		list( $doc_id, $attach_id ) = $this->create_document_with_attachment();
+		WP_Document_Revisions_AI_Summary::store( $attach_id, 'unavailable', '', '' );
+
+		$response = $this->server->dispatch(
+			new WP_REST_Request( 'GET', $this->summary_route( $doc_id, $attach_id ) )
+		);
+
+		self::assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		self::assertSame( 'unavailable', $data['status'] );
+		self::assertArrayNotHasKey( 'summary', $data, 'unavailable response should not expose a summary field' );
+	}
+
+	/**
+	 * Anonymous callers are rejected on the read endpoint.
+	 */
+	public function test_get_requires_read_document_capability() {
+		wp_set_current_user( 0 );
+		list( $doc_id, $attach_id ) = $this->create_document_with_attachment();
+
+		$response = $this->server->dispatch(
+			new WP_REST_Request( 'GET', $this->summary_route( $doc_id, $attach_id ) )
+		);
+
+		self::assertContains( $response->get_status(), array( 401, 403 ) );
+	}
+
+	/**
+	 * GET returns 404 when the revision does not belong to the claimed
+	 * document — by design, so the response shape cannot be used to
+	 * probe attachment-to-document relationships without authorisation.
+	 */
+	public function test_get_returns_404_when_revision_does_not_match_document() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		list( $doc_a, ) = $this->create_document_with_attachment();
+		list( , $rev_b ) = $this->create_document_with_attachment();
+
+		$response = $this->server->dispatch(
+			new WP_REST_Request( 'GET', $this->summary_route( $doc_a, $rev_b ) )
+		);
+
+		self::assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * POST review marks the summary reviewed by the current user when
+	 * a summary has already been stored.
+	 */
+	public function test_review_marks_summary_reviewed() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		list( $doc_id, $attach_id ) = $this->create_document_with_attachment();
+		WP_Document_Revisions_AI_Summary::store( $attach_id, 'change', 'summary', 'hash' );
+
+		$request = new WP_REST_Request( 'POST', $this->summary_route( $doc_id, $attach_id, '/review' ) );
+		$request->set_param( 'reviewed', true );
+		$response = $this->server->dispatch( $request );
+
+		self::assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		self::assertSame( $editor_id, $data['reviewed_by'] );
+		self::assertGreaterThan( 0, $data['reviewed_at'] );
+	}
+
+	/**
+	 * POST review with reviewed=false un-marks a previously-reviewed
+	 * summary.
+	 */
+	public function test_review_unmarks_when_reviewed_false() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		list( $doc_id, $attach_id ) = $this->create_document_with_attachment();
+		WP_Document_Revisions_AI_Summary::store( $attach_id, 'change', 'summary', 'hash' );
+		WP_Document_Revisions_AI_Summary::set_reviewed( $attach_id, $editor_id );
+
+		$request = new WP_REST_Request( 'POST', $this->summary_route( $doc_id, $attach_id, '/review' ) );
+		$request->set_param( 'reviewed', false );
+		$response = $this->server->dispatch( $request );
+
+		self::assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		self::assertSame( 0, $data['reviewed_by'] );
+		self::assertSame( 0, $data['reviewed_at'] );
+	}
+
+	/**
+	 * Subscribers (no edit_document cap) are rejected on the review endpoint.
+	 */
+	public function test_review_requires_edit_document_capability() {
+		$sub_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $sub_id );
+
+		list( $doc_id, $attach_id ) = $this->create_document_with_attachment();
+		WP_Document_Revisions_AI_Summary::store( $attach_id, 'change', 'summary', 'hash' );
+
+		$request = new WP_REST_Request( 'POST', $this->summary_route( $doc_id, $attach_id, '/review' ) );
+		$response = $this->server->dispatch( $request );
+
+		self::assertContains( $response->get_status(), array( 401, 403 ) );
+	}
+
+	/**
+	 * POST review returns 404 when there is nothing to review yet
+	 * (cron has not produced a summary for this revision).
+	 */
+	public function test_review_returns_404_when_no_summary_exists() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		list( $doc_id, $attach_id ) = $this->create_document_with_attachment();
+
+		$request = new WP_REST_Request( 'POST', $this->summary_route( $doc_id, $attach_id, '/review' ) );
+		$response = $this->server->dispatch( $request );
+
+		self::assertSame( 404, $response->get_status() );
+	}
+}

--- a/tests/class-test-wp-document-revisions-ai-summary-rest.php
+++ b/tests/class-test-wp-document-revisions-ai-summary-rest.php
@@ -154,7 +154,7 @@ class Test_WP_Document_Revisions_AI_Summary_REST extends Test_Common_WPDR {
 	 */
 	public function test_get_returns_404_when_revision_does_not_match_document() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
-		list( $doc_a, ) = $this->create_document_with_attachment();
+		list( $doc_a, )  = $this->create_document_with_attachment();
 		list( , $rev_b ) = $this->create_document_with_attachment();
 
 		$response = $this->server->dispatch(
@@ -217,7 +217,7 @@ class Test_WP_Document_Revisions_AI_Summary_REST extends Test_Common_WPDR {
 		list( $doc_id, $attach_id ) = $this->create_document_with_attachment();
 		WP_Document_Revisions_AI_Summary::store( $attach_id, 'change', 'summary', 'hash' );
 
-		$request = new WP_REST_Request( 'POST', $this->summary_route( $doc_id, $attach_id, '/review' ) );
+		$request  = new WP_REST_Request( 'POST', $this->summary_route( $doc_id, $attach_id, '/review' ) );
 		$response = $this->server->dispatch( $request );
 
 		self::assertContains( $response->get_status(), array( 401, 403 ) );
@@ -233,7 +233,7 @@ class Test_WP_Document_Revisions_AI_Summary_REST extends Test_Common_WPDR {
 
 		list( $doc_id, $attach_id ) = $this->create_document_with_attachment();
 
-		$request = new WP_REST_Request( 'POST', $this->summary_route( $doc_id, $attach_id, '/review' ) );
+		$request  = new WP_REST_Request( 'POST', $this->summary_route( $doc_id, $attach_id, '/review' ) );
 		$response = $this->server->dispatch( $request );
 
 		self::assertSame( 404, $response->get_status() );

--- a/tests/class-test-wp-document-revisions-ai-summary.php
+++ b/tests/class-test-wp-document-revisions-ai-summary.php
@@ -126,7 +126,7 @@ class Test_WP_Document_Revisions_AI_Summary extends Test_Common_WPDR {
 	}
 
 	/**
-	 * maybe_schedule queues a single cron event for a revision attachment.
+	 * Scheduling queues a single cron event for a revision attachment.
 	 */
 	public function test_maybe_schedule_queues_cron_event() {
 		list( , $attach_id ) = $this->attach_revision( 'body' );
@@ -142,8 +142,8 @@ class Test_WP_Document_Revisions_AI_Summary extends Test_Common_WPDR {
 	}
 
 	/**
-	 * maybe_schedule skips attachments whose parent document is
-	 * opted out of text extraction.
+	 * Scheduling skips attachments whose parent document is opted out
+	 * of text extraction.
 	 */
 	public function test_maybe_schedule_skips_opted_out_document() {
 		list( $doc_id, $attach_id ) = $this->attach_revision( 'body' );
@@ -216,9 +216,9 @@ class Test_WP_Document_Revisions_AI_Summary extends Test_Common_WPDR {
 			}
 		);
 
-		list( $doc_id, $first_id ) = $this->attach_revision( "same text" );
+		list( $doc_id, $first_id ) = $this->attach_revision( 'same text' );
 		wpdr_extract_text( $first_id );
-		list( , $second_id )       = $this->attach_revision( "same text", $doc_id );
+		list( , $second_id ) = $this->attach_revision( 'same text', $doc_id );
 
 		WP_Document_Revisions_AI_Summary::run( $second_id );
 
@@ -248,7 +248,7 @@ class Test_WP_Document_Revisions_AI_Summary extends Test_Common_WPDR {
 
 		list( $doc_id, $first_id ) = $this->attach_revision( "alpha\nbeta" );
 		wpdr_extract_text( $first_id );
-		list( , $second_id )       = $this->attach_revision( "completely different\nlines\nhere", $doc_id );
+		list( , $second_id ) = $this->attach_revision( "completely different\nlines\nhere", $doc_id );
 
 		WP_Document_Revisions_AI_Summary::run( $second_id );
 
@@ -311,7 +311,7 @@ class Test_WP_Document_Revisions_AI_Summary extends Test_Common_WPDR {
 			}
 		);
 
-		list( , $attach_id ) = $this->attach_revision( "something" );
+		list( , $attach_id ) = $this->attach_revision( 'something' );
 
 		WP_Document_Revisions_AI_Summary::run( $attach_id );
 
@@ -378,7 +378,8 @@ class Test_WP_Document_Revisions_AI_Summary extends Test_Common_WPDR {
 
 		add_filter(
 			'wpdr_ai_summary_prompt',
-			static function ( string $default, string $kind, int $rev_id ) use ( &$captured_kind, &$captured_revision_id ): string {
+			static function ( string $ignored_default, string $kind, int $rev_id ) use ( &$captured_kind, &$captured_revision_id ): string {
+				unset( $ignored_default );
 				$captured_kind        = $kind;
 				$captured_revision_id = $rev_id;
 				return 'CUSTOM PROMPT';
@@ -388,7 +389,8 @@ class Test_WP_Document_Revisions_AI_Summary extends Test_Common_WPDR {
 		);
 		add_filter(
 			'wpdr_ai_summary_generator',
-			static function ( $default, string $prompt ) use ( &$captured_prompt_passed ): string {
+			static function ( $ignored_default, string $prompt ) use ( &$captured_prompt_passed ): string {
+				unset( $ignored_default );
 				$captured_prompt_passed = $prompt;
 				return 'ok';
 			},
@@ -396,7 +398,7 @@ class Test_WP_Document_Revisions_AI_Summary extends Test_Common_WPDR {
 			2
 		);
 
-		list( , $attach_id ) = $this->attach_revision( "first revision text" );
+		list( , $attach_id ) = $this->attach_revision( 'first revision text' );
 		WP_Document_Revisions_AI_Summary::run( $attach_id );
 
 		self::assertSame( 'document', $captured_kind, 'First revision uses document kind' );
@@ -406,13 +408,13 @@ class Test_WP_Document_Revisions_AI_Summary extends Test_Common_WPDR {
 	}
 
 	/**
-	 * prior_revision_id walks the document's attachments and returns
-	 * the entry immediately after the given one (older revision).
+	 * Finding the prior revision walks the document's attachments and
+	 * returns the entry immediately older than the given one.
 	 */
 	public function test_prior_revision_id_returns_immediately_older_attachment() {
-		list( $doc_id, $first_id )  = $this->attach_revision( 'one' );
-		list( , $second_id )        = $this->attach_revision( 'two', $doc_id );
-		list( , $third_id )         = $this->attach_revision( 'three', $doc_id );
+		list( $doc_id, $first_id ) = $this->attach_revision( 'one' );
+		list( , $second_id )       = $this->attach_revision( 'two', $doc_id );
+		list( , $third_id )        = $this->attach_revision( 'three', $doc_id );
 
 		self::assertSame( $second_id, WP_Document_Revisions_AI_Summary::prior_revision_id( $third_id, $doc_id ) );
 		self::assertSame( $first_id, WP_Document_Revisions_AI_Summary::prior_revision_id( $second_id, $doc_id ) );
@@ -420,8 +422,8 @@ class Test_WP_Document_Revisions_AI_Summary extends Test_Common_WPDR {
 	}
 
 	/**
-	 * set_reviewed writes the reviewer ID + timestamp when given a
-	 * positive user ID, and clears them when given 0.
+	 * Setting reviewed writes the reviewer ID + timestamp when given
+	 * a positive user ID, and clears them when given 0.
 	 */
 	public function test_set_reviewed_writes_and_clears_meta() {
 		$this->register_counting_fake();

--- a/tests/class-test-wp-document-revisions-ai-summary.php
+++ b/tests/class-test-wp-document-revisions-ai-summary.php
@@ -1,0 +1,468 @@
+<?php
+/**
+ * Tests for the AI summary generator + storage layer.
+ *
+ * Phase 11 of issue #514: verifies the cache-trigger → cron-schedule
+ * → generate → store pipeline, the diff-status → summary-kind mapping,
+ * the input-hash-based cache, the prompt filter, the opt-out skip
+ * paths, and the review-state operations.
+ *
+ * The WordPress 7.0 AI Client is mocked via the
+ * `wpdr_ai_summary_generator` and `wpdr_ai_summary_available` filters
+ * so the suite runs without a live provider.
+ *
+ * @package WP_Document_Revisions
+ */
+
+/**
+ * Tests for WP_Document_Revisions_AI_Summary.
+ */
+class Test_WP_Document_Revisions_AI_Summary extends Test_Common_WPDR {
+
+	/**
+	 * Load the counting-fake extractor for cache-warming.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once __DIR__ . '/class-wpdr-test-counting-text-extractor.php';
+	}
+
+	/**
+	 * Reset filters + cron between tests so injected generators do
+	 * not leak.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'wpdr_text_extractors' );
+		remove_all_filters( 'wpdr_ai_summary_available' );
+		remove_all_filters( 'wpdr_ai_summary_generator' );
+		remove_all_filters( 'wpdr_ai_summary_prompt' );
+		remove_all_filters( 'wpdr_ai_summary_delay' );
+		_set_cron_array( array() );
+		parent::tear_down();
+	}
+
+	/**
+	 * Force-enable the AI pipeline and return a canned summary for
+	 * every prompt the test exercises.
+	 *
+	 * @param string $canned Text to return from the injected generator.
+	 * @return void
+	 */
+	private function inject_canned_generator( string $canned = 'Canned summary for testing.' ): void {
+		add_filter( 'wpdr_ai_summary_available', '__return_true' );
+		add_filter(
+			'wpdr_ai_summary_generator',
+			static function () use ( $canned ): string {
+				return $canned;
+			}
+		);
+	}
+
+	/**
+	 * Register a counting fake extractor that reads file contents
+	 * verbatim, so two attachments with distinct bodies produce
+	 * distinct extracted text.
+	 *
+	 * @return WPDR_Test_Counting_Text_Extractor the registered fake.
+	 */
+	private function register_counting_fake(): WPDR_Test_Counting_Text_Extractor {
+		$fake = new WPDR_Test_Counting_Text_Extractor( 'text/plain' );
+		add_filter(
+			'wpdr_text_extractors',
+			static function ( array $extractors ) use ( $fake ): array {
+				array_unshift( $extractors, $fake );
+				return $extractors;
+			}
+		);
+		return $fake;
+	}
+
+	/**
+	 * Create a document, attach a text file with the given body, and
+	 * return its revision attachment ID.
+	 *
+	 * @param string $body file body to write before attaching.
+	 * @param int    $doc_id existing document ID to attach to, or 0 to create one.
+	 * @return array{0:int,1:int} [ document_id, attachment_id ].
+	 */
+	private function attach_revision( string $body, int $doc_id = 0 ): array {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( self::$test_file, $body );
+
+		if ( 0 === $doc_id ) {
+			$doc_id = self::factory()->post->create(
+				array(
+					'post_title'  => 'AI Summary Test Document',
+					'post_type'   => 'document',
+					'post_status' => 'publish',
+				)
+			);
+		}
+		self::add_document_attachment( self::factory(), $doc_id, self::$test_file );
+
+		global $wpdr;
+		$revision = $wpdr->get_latest_revision( $doc_id );
+		return array( (int) $doc_id, (int) $revision->post_content );
+	}
+
+	/**
+	 * Cache::set() fires the wpdr_text_extracted action so the summary
+	 * scheduler can queue itself.
+	 */
+	public function test_cache_set_fires_wpdr_text_extracted_action() {
+		$captured = 0;
+		add_action(
+			'wpdr_text_extracted',
+			static function ( int $id ) use ( &$captured ): void {
+				$captured = $id;
+			}
+		);
+
+		list( , $attach_id ) = $this->attach_revision( 'hello' );
+		$file_path           = get_attached_file( $attach_id );
+		WP_Document_Revisions_Text_Extractor_Cache::set( $attach_id, $file_path, 'hello', 'X' );
+
+		self::assertSame( $attach_id, $captured, 'wpdr_text_extracted should fire with the attachment ID' );
+	}
+
+	/**
+	 * maybe_schedule queues a single cron event for a revision attachment.
+	 */
+	public function test_maybe_schedule_queues_cron_event() {
+		list( , $attach_id ) = $this->attach_revision( 'body' );
+		_set_cron_array( array() );
+
+		WP_Document_Revisions_AI_Summary::maybe_schedule( $attach_id );
+
+		$next = wp_next_scheduled(
+			WP_Document_Revisions_AI_Summary::CRON_ACTION,
+			array( $attach_id )
+		);
+		self::assertIsInt( $next );
+	}
+
+	/**
+	 * maybe_schedule skips attachments whose parent document is
+	 * opted out of text extraction.
+	 */
+	public function test_maybe_schedule_skips_opted_out_document() {
+		list( $doc_id, $attach_id ) = $this->attach_revision( 'body' );
+		update_post_meta( $doc_id, WP_Document_Revisions_Text_Extraction_Opt_Out::META_KEY, '1' );
+		_set_cron_array( array() );
+
+		WP_Document_Revisions_AI_Summary::maybe_schedule( $attach_id );
+
+		self::assertFalse(
+			wp_next_scheduled(
+				WP_Document_Revisions_AI_Summary::CRON_ACTION,
+				array( $attach_id )
+			)
+		);
+	}
+
+	/**
+	 * Initial upload (no prior revision) routes to the 'document' kind
+	 * and sends the new text to the AI Client.
+	 */
+	public function test_run_first_revision_uses_document_kind() {
+		$this->register_counting_fake();
+		$this->inject_canned_generator( 'doc summary' );
+		list( , $attach_id ) = $this->attach_revision( "alpha\nbeta" );
+
+		WP_Document_Revisions_AI_Summary::run( $attach_id );
+
+		$stored = WP_Document_Revisions_AI_Summary::get( $attach_id );
+		self::assertIsArray( $stored );
+		self::assertSame( 'document', $stored['kind'] );
+		self::assertSame( 'doc summary', $stored['text'] );
+	}
+
+	/**
+	 * Second revision with distinct text routes to 'change' kind.
+	 */
+	public function test_run_second_revision_with_diff_uses_change_kind() {
+		$this->register_counting_fake();
+		$this->inject_canned_generator( 'change summary' );
+
+		list( $doc_id, $first_id ) = $this->attach_revision( "alpha\nbeta\ngamma" );
+		// Warm the cache for the first revision so the diff lookup
+		// finds prior text.
+		wpdr_extract_text( $first_id );
+
+		list( , $second_id ) = $this->attach_revision( "alpha\nBETA\ngamma", $doc_id );
+
+		WP_Document_Revisions_AI_Summary::run( $second_id );
+
+		$stored = WP_Document_Revisions_AI_Summary::get( $second_id );
+		self::assertIsArray( $stored );
+		self::assertSame( 'change', $stored['kind'] );
+		self::assertSame( 'change summary', $stored['text'] );
+	}
+
+	/**
+	 * Identical text between prior and new revision routes to
+	 * 'no_change' kind WITHOUT invoking the AI client (the fixed
+	 * message is stored directly).
+	 */
+	public function test_run_identical_text_uses_no_change_kind_without_ai_call() {
+		$this->register_counting_fake();
+		add_filter( 'wpdr_ai_summary_available', '__return_true' );
+		$ai_calls = 0;
+		add_filter(
+			'wpdr_ai_summary_generator',
+			static function () use ( &$ai_calls ): string {
+				++$ai_calls;
+				return 'should-not-be-stored';
+			}
+		);
+
+		list( $doc_id, $first_id ) = $this->attach_revision( "same text" );
+		wpdr_extract_text( $first_id );
+		list( , $second_id )       = $this->attach_revision( "same text", $doc_id );
+
+		WP_Document_Revisions_AI_Summary::run( $second_id );
+
+		$stored = WP_Document_Revisions_AI_Summary::get( $second_id );
+		self::assertSame( 'no_change', $stored['kind'] );
+		self::assertSame(
+			WP_Document_Revisions_AI_Summary::NO_CHANGE_MESSAGE,
+			$stored['text']
+		);
+		self::assertSame( 0, $ai_calls, 'no_change should not invoke the AI client' );
+	}
+
+	/**
+	 * `too_large` from the diff utility falls back to a 'document'
+	 * summary of the new text. Forced via a tight `max_chars` filter
+	 * so the test fixture doesn't have to produce a real megabyte diff.
+	 */
+	public function test_run_too_large_diff_falls_back_to_document_kind() {
+		$this->register_counting_fake();
+		$this->inject_canned_generator( 'fallback doc summary' );
+		add_filter(
+			'wpdr_text_diff_max_chars',
+			static function (): int {
+				return 5;
+			}
+		);
+
+		list( $doc_id, $first_id ) = $this->attach_revision( "alpha\nbeta" );
+		wpdr_extract_text( $first_id );
+		list( , $second_id )       = $this->attach_revision( "completely different\nlines\nhere", $doc_id );
+
+		WP_Document_Revisions_AI_Summary::run( $second_id );
+
+		$stored = WP_Document_Revisions_AI_Summary::get( $second_id );
+		self::assertSame( 'document', $stored['kind'] );
+		self::assertSame( 'fallback doc summary', $stored['text'] );
+	}
+
+	/**
+	 * When the prior revision has no extracted text (scanned PDF, etc.)
+	 * the run falls back to a 'document' summary of the new text.
+	 *
+	 * Manually populates the prior revision's cache with an empty
+	 * extraction (simulating the scanned-PDF / unsupported-format
+	 * case) instead of trying to register two different extractors
+	 * for the same MIME type.
+	 */
+	public function test_run_old_text_missing_falls_back_to_document_kind() {
+		list( $doc_id, $first_id ) = $this->attach_revision( 'old' );
+		$first_path                = get_attached_file( $first_id );
+		WP_Document_Revisions_Text_Extractor_Cache::set( $first_id, $first_path, '', 'TestExtractor' );
+
+		// Register the file-reading fake AFTER the prior cache is set,
+		// so the second revision (cache cold) extracts via the fake
+		// while the first (cache hit on '') stays empty.
+		$this->register_counting_fake();
+		$this->inject_canned_generator( 'doc-only summary' );
+
+		list( , $second_id ) = $this->attach_revision( 'new text content', $doc_id );
+
+		WP_Document_Revisions_AI_Summary::run( $second_id );
+
+		$stored = WP_Document_Revisions_AI_Summary::get( $second_id );
+		self::assertSame( 'document', $stored['kind'] );
+		self::assertSame( 'doc-only summary', $stored['text'] );
+	}
+
+	/**
+	 * When the new revision has no extracted text the run stores an
+	 * 'unavailable' record without invoking the AI client. This is
+	 * the contract that lets phase 12's UI render "summary pending"
+	 * rather than "generation failed."
+	 */
+	public function test_run_new_text_missing_stores_unavailable_without_ai_call() {
+		$empty_fake = new WPDR_Test_Counting_Text_Extractor( 'text/plain', '' );
+		add_filter(
+			'wpdr_text_extractors',
+			static function ( array $extractors ) use ( $empty_fake ): array {
+				array_unshift( $extractors, $empty_fake );
+				return $extractors;
+			}
+		);
+		add_filter( 'wpdr_ai_summary_available', '__return_true' );
+		$ai_calls = 0;
+		add_filter(
+			'wpdr_ai_summary_generator',
+			static function () use ( &$ai_calls ): string {
+				++$ai_calls;
+				return 'unreachable';
+			}
+		);
+
+		list( , $attach_id ) = $this->attach_revision( "something" );
+
+		WP_Document_Revisions_AI_Summary::run( $attach_id );
+
+		$stored = WP_Document_Revisions_AI_Summary::get( $attach_id );
+		self::assertSame( 'unavailable', $stored['kind'] );
+		self::assertSame( '', $stored['text'] );
+		self::assertSame( 0, $ai_calls );
+	}
+
+	/**
+	 * When the WP AI Client is unavailable, run() stores nothing —
+	 * deliberately leaving the meta absent so a future cron pass
+	 * after WP 7.0 is enabled produces a real summary.
+	 */
+	public function test_run_skips_when_ai_unavailable() {
+		$this->register_counting_fake();
+		add_filter( 'wpdr_ai_summary_available', '__return_false' );
+
+		list( , $attach_id ) = $this->attach_revision( "alpha\nbeta" );
+
+		WP_Document_Revisions_AI_Summary::run( $attach_id );
+
+		self::assertNull(
+			WP_Document_Revisions_AI_Summary::get( $attach_id ),
+			'AI-unavailable run() should leave the summary meta absent'
+		);
+	}
+
+	/**
+	 * Re-running cron against unchanged inputs is a no-op (the AI
+	 * client is not re-invoked).
+	 */
+	public function test_run_is_idempotent_for_unchanged_inputs() {
+		$this->register_counting_fake();
+		add_filter( 'wpdr_ai_summary_available', '__return_true' );
+		$ai_calls = 0;
+		add_filter(
+			'wpdr_ai_summary_generator',
+			static function () use ( &$ai_calls ): string {
+				++$ai_calls;
+				return 'summary';
+			}
+		);
+
+		list( , $attach_id ) = $this->attach_revision( "alpha\nbeta" );
+		WP_Document_Revisions_AI_Summary::run( $attach_id );
+		WP_Document_Revisions_AI_Summary::run( $attach_id );
+
+		self::assertSame( 1, $ai_calls, 'AI should only be called once for unchanged inputs' );
+	}
+
+	/**
+	 * The wpdr_ai_summary_prompt filter receives the kind and revision
+	 * ID (but not the input text) and the returned template is what
+	 * the AI sees, prepended to the input.
+	 */
+	public function test_prompt_filter_sees_kind_and_revision_id() {
+		$this->register_counting_fake();
+		add_filter( 'wpdr_ai_summary_available', '__return_true' );
+
+		$captured_kind          = '';
+		$captured_revision_id   = 0;
+		$captured_prompt_passed = '';
+
+		add_filter(
+			'wpdr_ai_summary_prompt',
+			static function ( string $default, string $kind, int $rev_id ) use ( &$captured_kind, &$captured_revision_id ): string {
+				$captured_kind        = $kind;
+				$captured_revision_id = $rev_id;
+				return 'CUSTOM PROMPT';
+			},
+			10,
+			3
+		);
+		add_filter(
+			'wpdr_ai_summary_generator',
+			static function ( $default, string $prompt ) use ( &$captured_prompt_passed ): string {
+				$captured_prompt_passed = $prompt;
+				return 'ok';
+			},
+			10,
+			2
+		);
+
+		list( , $attach_id ) = $this->attach_revision( "first revision text" );
+		WP_Document_Revisions_AI_Summary::run( $attach_id );
+
+		self::assertSame( 'document', $captured_kind, 'First revision uses document kind' );
+		self::assertSame( $attach_id, $captured_revision_id );
+		self::assertStringStartsWith( 'CUSTOM PROMPT', $captured_prompt_passed );
+		self::assertStringContainsString( 'first revision text', $captured_prompt_passed );
+	}
+
+	/**
+	 * prior_revision_id walks the document's attachments and returns
+	 * the entry immediately after the given one (older revision).
+	 */
+	public function test_prior_revision_id_returns_immediately_older_attachment() {
+		list( $doc_id, $first_id )  = $this->attach_revision( 'one' );
+		list( , $second_id )        = $this->attach_revision( 'two', $doc_id );
+		list( , $third_id )         = $this->attach_revision( 'three', $doc_id );
+
+		self::assertSame( $second_id, WP_Document_Revisions_AI_Summary::prior_revision_id( $third_id, $doc_id ) );
+		self::assertSame( $first_id, WP_Document_Revisions_AI_Summary::prior_revision_id( $second_id, $doc_id ) );
+		self::assertSame( 0, WP_Document_Revisions_AI_Summary::prior_revision_id( $first_id, $doc_id ) );
+	}
+
+	/**
+	 * set_reviewed writes the reviewer ID + timestamp when given a
+	 * positive user ID, and clears them when given 0.
+	 */
+	public function test_set_reviewed_writes_and_clears_meta() {
+		$this->register_counting_fake();
+		$this->inject_canned_generator( 'summary' );
+		list( , $attach_id ) = $this->attach_revision( 'body' );
+		WP_Document_Revisions_AI_Summary::run( $attach_id );
+
+		$reviewer = self::factory()->user->create();
+		self::assertTrue( WP_Document_Revisions_AI_Summary::set_reviewed( $attach_id, $reviewer ) );
+
+		$stored = WP_Document_Revisions_AI_Summary::get( $attach_id );
+		self::assertSame( $reviewer, $stored['reviewed_by'] );
+		self::assertGreaterThan( 0, $stored['reviewed_at'] );
+
+		self::assertTrue( WP_Document_Revisions_AI_Summary::set_reviewed( $attach_id, 0 ) );
+		$stored = WP_Document_Revisions_AI_Summary::get( $attach_id );
+		self::assertSame( 0, $stored['reviewed_by'] );
+		self::assertSame( 0, $stored['reviewed_at'] );
+	}
+
+	/**
+	 * Storing a new summary clears any prior review state — the
+	 * previous review applied to text that no longer reflects the
+	 * current revision.
+	 */
+	public function test_store_clears_prior_review_state() {
+		$this->register_counting_fake();
+		$this->inject_canned_generator( 'first' );
+		list( , $attach_id ) = $this->attach_revision( 'body' );
+		WP_Document_Revisions_AI_Summary::run( $attach_id );
+
+		$reviewer = self::factory()->user->create();
+		WP_Document_Revisions_AI_Summary::set_reviewed( $attach_id, $reviewer );
+
+		// Direct store() with a different input_hash simulates the
+		// invariant the cron run upholds: a new summary lands.
+		WP_Document_Revisions_AI_Summary::store( $attach_id, 'document', 'second', 'different-hash' );
+
+		$stored = WP_Document_Revisions_AI_Summary::get( $attach_id );
+		self::assertSame( 'second', $stored['text'] );
+		self::assertSame( 0, $stored['reviewed_by'], 'Reviewing should be reset on new summary' );
+		self::assertSame( 0, $stored['reviewed_at'] );
+	}
+}

--- a/tests/class-test-wp-document-revisions-validate.php
+++ b/tests/class-test-wp-document-revisions-validate.php
@@ -713,8 +713,12 @@ class Test_WP_Document_Revisions_Validate extends Test_Common_WPDR {
 	 */
 	public function test_endpoints() {
 		global $wp_rest_server;
-		// only want the default documents one and not the namespace one.
-		$the_route = $this->namespaced_route . '/';
+		// Only inspect the validate-structure `/correct/` route shape;
+		// other routes registered under the same namespace (the AI
+		// summary routes added in #514 phase 11, for example) have a
+		// different shape and would trip the per-route assertions
+		// below if iterated here.
+		$the_route = $this->namespaced_route . '/correct/';
 		$routes    = $wp_rest_server->get_routes( $this->namespaced_route );
 		self::assertNotEmpty( $routes, 'No document routes' );
 

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -101,6 +101,7 @@ require_once __DIR__ . '/includes/class-wp-document-revisions-text-extractor-sch
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-extraction-opt-out.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-diff.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-ai-summary.php';
+require_once __DIR__ . '/includes/class-wp-document-revisions-ai-summary-rest.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-pdf-text-extractor.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-docx-text-extractor.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions.php';
@@ -138,6 +139,10 @@ WP_Document_Revisions_Text_Extraction_Opt_Out::init();
 // available; the cron event is still scheduled so a future site
 // upgrade does not require re-extracting historical content.
 WP_Document_Revisions_AI_Summary::init();
+
+// Register the read + review REST endpoints. Generation is intentionally
+// NOT exposed over REST — cron drives it after extraction completes.
+WP_Document_Revisions_AI_Summary_REST::init();
 
 // Register the WP-CLI backfill command when running under WP-CLI.
 if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -100,6 +100,7 @@ require_once __DIR__ . '/includes/class-wp-document-revisions-text-extractor-cac
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-extractor-scheduler.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-extraction-opt-out.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-text-diff.php';
+require_once __DIR__ . '/includes/class-wp-document-revisions-ai-summary.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-pdf-text-extractor.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions-docx-text-extractor.php';
 require_once __DIR__ . '/includes/class-wp-document-revisions.php';
@@ -130,6 +131,13 @@ WP_Document_Revisions_Text_Extractor_Scheduler::init();
 
 // Register the per-document opt-out meta box and save handler (admin only).
 WP_Document_Revisions_Text_Extraction_Opt_Out::init();
+
+// Register the AI summary cron handler (hooks wpdr_text_extracted →
+// queues a single cron event to generate the summary off the request
+// thread). Generation skips silently when the WP 7.0 AI Client is not
+// available; the cron event is still scheduled so a future site
+// upgrade does not require re-extracting historical content.
+WP_Document_Revisions_AI_Summary::init();
 
 // Register the WP-CLI backfill command when running under WP-CLI.
 if ( defined( 'WP_CLI' ) && WP_CLI ) {


### PR DESCRIPTION
## Summary

Lands the server-side half of the AI-generated revision summary feature. Phase 12 (the admin-editor JS that pre-fills the revision log) will be the first consumer of these endpoints.

**Cron-driven generation, not POST-triggered.** The summary scheduler hooks the new `wpdr_text_extracted` action that `Cache::set()` fires, then runs ~10s later — same shape as the phase 7 extractor scheduler. REST endpoints are read-only. This avoids holding an HTTP request open for seconds against an AI provider, which is bad UX, breaks on shared-hosting timeouts, and pushes browser-side latency that the user has no control over.

**WordPress 7.0 ready, older-WP safe.** Calls `wp_ai_client_prompt( $prompt )->generate_text()` (the WP 7.0 entry point) when available; honours `WP_AI_SUPPORT` and `function_exists()` checks otherwise. Sites running older WordPress get scheduled cron events that silently skip — no error spam, no broken paths. When a site upgrades to WP 7.0, the next extraction round produces summaries normally.

**Diff status → summary kind mapping** (made explicit per advisor feedback):

| Diff status | Summary kind | What happens |
|---|---|---|
| `ok` | `change` | Send the diff to the AI |
| `identical` | `no_change` | Store a fixed message, no AI call |
| `too_large` | `document` | Summarise the new text directly |
| `old_text_missing` | `document` | No prior text to diff against |
| `new_text_missing` | `unavailable` | Can't summarise yet; will retry when extraction completes |
| no prior revision | `document` | Initial upload |

**Capability mapping follows @NeilWJames's input from [issue #514](https://github.com/wp-document-revisions/wp-document-revisions/issues/514#issuecomment-4526090398):**

- GET summary → `read_document` (gated like reading the file itself)
- POST review → `edit_document`
- Diff records → not exposed in this phase (would be `read_document_revisions`)
- Generation itself → no cap check, server-side cron only

**404, not 401, on cross-document mismatch.** Both endpoints verify the claimed revision belongs to the claimed document. Mismatch returns 404 deliberately so unauthorised callers can't probe attachment-to-document relationships through response shape.

## Commits

1. `4af22b2` — Summary generator class + cron wiring + storage + 17 tests
2. `d589423` — REST controller + 9 endpoint tests

## Test plan

- [ ] CI green (PHPCS, PHPStan, PHPUnit across PHP/WP matrix)
- [ ] Manual smoke (without WP 7.0): upload a revision, observe `wp cron event list` includes a `wpdr_generate_ai_summary` event for the attachment, run the event, inspect attachment post meta — nothing stored (because AI unavailable), no errors
- [ ] Manual smoke (with WP 7.0 + an AI provider connector): same flow, but the cron run populates `_wpdr_ai_summary_text` + `_wpdr_ai_summary_kind`
- [ ] Manual smoke: `GET /wp-json/wpdr/v1/documents/<id>/revisions/<rev>/summary` returns `{status: 'pending'}` before the cron runs, `{status: 'ready', summary: …}` after
- [ ] Manual smoke: `POST /wp-json/wpdr/v1/documents/<id>/revisions/<rev>/summary/review` with `reviewed: true` from an editor account; subscriber accounts get 403
- [ ] Manual smoke: opt out a document, verify the summary cron skips it
- [ ] Cross-doc 404: GET with `doc_a + rev_b` (where rev_b belongs to a different document) returns 404

Closes phase 11 of #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)