### PR TITLE
Release 4.1.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,21 @@
 
 Numbers in brackets show the issue number in https://github.com/wp-document-revisions/wp-document-revisions/issues/
 
+### 4.1.0
+
+Adds native text extraction and AI-generated revision summaries for document libraries. The full design and the twelve PRs that implemented it are tracked in #514; a smaller set of deferred follow-ups is in #531.
+
+#### Features
+
+* #514: Native text extraction from PDF (via `smalot/pdfparser`), DOCX, and ODT (via `phpoffice/phpword`). Extraction runs out-of-band via wp-cron after a revision is uploaded; results are SHA-256-keyed against the file's contents and stored as post meta on the attachment so re-extracting unchanged content is a no-op. New `wpdr_text_extractors` filter lets a site register custom extractors for additional formats (see the [cookbook recipe](cookbook/text-extraction-and-ai-summaries.md#recipe-1-register-a-custom-extractor)).
+* #514: AI-generated revision summaries via the [WordPress 7.0 AI Client](https://make.wordpress.org/core/2026/03/24/introducing-the-ai-client-in-wordpress-7-0/). After extraction completes, a second cron event computes a unified diff between the new revision's text and the prior revision's, sends it to the AI Client with a filterable prompt, and stores the 1–3-sentence summary as post meta on the attachment. Falls back gracefully to summarising the new document directly when the diff is too large or the prior revision has no extractable text. Skips silently when the AI Client is unavailable (older WordPress) or `WP_AI_SUPPORT` is `false`.
+* #514: Admin-editor JS pre-fills the AI summary into the revision log textarea on the document edit screen, with a dismiss link. Never clobbers user-typed content. Per-document opt-out ("Do not pre-fill the revision log with AI suggestions") in a new "Text Extraction & AI" sidebar meta box; sitewide opt-out via the `WPDR_AI_SUMMARY_PREFILL` constant.
+* #514: Per-document and sitewide opt-outs for text extraction itself ("Skip text extraction for this document" checkbox, `WPDR_TEXT_EXTRACTION` constant). Flipping the per-document opt-out on clears every cache-managed meta key on the document's revision attachments and unschedules pending cron events.
+* #514: WP-CLI `document-revisions extract-text` command for backfilling the extraction cache across an existing library. Selectors: `--all`, `--missing` (excludes failure-list entries to prevent infinite retry on malformed files), `--id=<id>`. Modifiers: `--extractor=<class>` to target reprocessing by tool identity, `--force` to bypass cache + failure list, `--dry-run`.
+* #514: Read + review REST endpoints under `wpdr/v1`. `GET /documents/<doc>/revisions/<rev>/summary` returns the cached summary with a `status` envelope (`pending` / `ready` / `unavailable`); `read_document` capability. `POST .../summary/review` marks a summary as human-reviewed; `edit_document` capability. Capability mapping by [@NeilWJames](https://github.com/NeilWJames).
+* #514: New action `wpdr_text_extracted` fires after extracted text is cached, so third-party search-indexing or embedding consumers can hook without monkey-patching the cache class.
+* Adds a [Text Extraction & AI Summaries cookbook recipe](cookbook/text-extraction-and-ai-summaries.md) covering custom extractors, prompt customization, the four opt-out switches, the WP-CLI backfill, alternative AI providers, and the REST surface.
+
 ### 4.0.7
 
 #### Bug Fixes

--- a/docs/features.md
+++ b/docs/features.md
@@ -36,6 +36,10 @@
 - Opt-in [Block Editor (Gutenberg) support](block-editor.md) with document sidebar panel (experimental)
 - REST API security hardening: attachment data sanitized for non-editors, attachment ownership validation
 - WordPress Abilities API integration (WP 6.9+) for AI agents and the command palette
+- Native text extraction from PDF, DOCX, and ODT files (pluggable for additional formats), cached per-attachment for search and AI use
+- AI-generated revision summaries via the [WordPress 7.0 AI Client](https://make.wordpress.org/core/2026/03/24/introducing-the-ai-client-in-wordpress-7-0/), computed from a unified diff of the new revision against the prior one and pre-filled into the revision log for editor review. See the [Text Extraction & AI cookbook entry](cookbook/text-extraction-and-ai-summaries.md) for customization recipes
+- WP-CLI `document-revisions extract-text` command to backfill the extraction cache across an existing library, with `--all`/`--missing`/`--id`/`--extractor`/`--force`/`--dry-run` selectors
+- Per-document and sitewide opt-outs for text extraction and AI pre-fill — extraction respects `WPDR_TEXT_EXTRACTION`, AI pre-fill respects `WPDR_AI_SUMMARY_PREFILL` and the core `WP_AI_SUPPORT` constant
 - Clean uninstall: options, user meta, and capabilities removed on plugin deletion
 - Deactivation hook flushes rewrite rules for clean deactivation
 - Recently Revised Documents Widget, shortcodes, and templating functions for front-end integration

--- a/docs/header.md
+++ b/docs/header.md
@@ -5,7 +5,7 @@ Tags: documents, document management, version control, collaboration, revisions
 Requires at least: 5.0
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 4.0.7
+Stable tag: 4.1.0
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: documents, document management, version control, collaboration, revisions
 Requires at least: 5.0
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 4.0.7
+Stable tag: 4.1.0
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -218,6 +218,21 @@ Interested in translating WP Document Revisions? You can do so [via Crowdin](htt
 == Changelog ==
 
 Numbers in brackets show the issue number in https://github.com/wp-document-revisions/wp-document-revisions/issues/
+
+= 4.1.0 =
+
+Adds native text extraction and AI-generated revision summaries for document libraries. The full design and the twelve PRs that implemented it are tracked in #514; a smaller set of deferred follow-ups is in #531.
+
+= # Features =
+
+* #514: Native text extraction from PDF (via `smalot/pdfparser`), DOCX, and ODT (via `phpoffice/phpword`). Extraction runs out-of-band via wp-cron after a revision is uploaded; results are SHA-256-keyed against the file's contents and stored as post meta on the attachment so re-extracting unchanged content is a no-op. New `wpdr_text_extractors` filter lets a site register custom extractors for additional formats (see the [cookbook recipe](https://wp-document-revisions.github.io/wp-document-revisions/cookbook/text-extraction-and-ai-summaries/#recipe-1-register-a-custom-extractor)).
+* #514: AI-generated revision summaries via the [WordPress 7.0 AI Client](https://make.wordpress.org/core/2026/03/24/introducing-the-ai-client-in-wordpress-7-0/). After extraction completes, a second cron event computes a unified diff between the new revision's text and the prior revision's, sends it to the AI Client with a filterable prompt, and stores the 1–3-sentence summary as post meta on the attachment. Falls back gracefully to summarising the new document directly when the diff is too large or the prior revision has no extractable text. Skips silently when the AI Client is unavailable (older WordPress) or `WP_AI_SUPPORT` is `false`.
+* #514: Admin-editor JS pre-fills the AI summary into the revision log textarea on the document edit screen, with a dismiss link. Never clobbers user-typed content. Per-document opt-out ("Do not pre-fill the revision log with AI suggestions") in a new "Text Extraction & AI" sidebar meta box; sitewide opt-out via the `WPDR_AI_SUMMARY_PREFILL` constant.
+* #514: Per-document and sitewide opt-outs for text extraction itself ("Skip text extraction for this document" checkbox, `WPDR_TEXT_EXTRACTION` constant). Flipping the per-document opt-out on clears every cache-managed meta key on the document's revision attachments and unschedules pending cron events.
+* #514: WP-CLI `document-revisions extract-text` command for backfilling the extraction cache across an existing library. Selectors: `--all`, `--missing` (excludes failure-list entries to prevent infinite retry on malformed files), `--id=<id>`. Modifiers: `--extractor=<class>` to target reprocessing by tool identity, `--force` to bypass cache + failure list, `--dry-run`.
+* #514: Read + review REST endpoints under `wpdr/v1`. `GET /documents/<doc>/revisions/<rev>/summary` returns the cached summary with a `status` envelope (`pending` / `ready` / `unavailable`); `read_document` capability. `POST .../summary/review` marks a summary as human-reviewed; `edit_document` capability. Capability mapping by [@NeilWJames](https://github.com/NeilWJames).
+* #514: New action `wpdr_text_extracted` fires after extracted text is cached, so third-party search-indexing or embedding consumers can hook without monkey-patching the cache class.
+* Adds a [Text Extraction & AI Summaries cookbook recipe](https://wp-document-revisions.github.io/wp-document-revisions/cookbook/text-extraction-and-ai-summaries/) covering custom extractors, prompt customization, the four opt-out switches, the WP-CLI backfill, alternative AI providers, and the REST surface.
 
 = 4.0.7 =
 

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Document Revisions
 Plugin URI: http://ben.balter.com/2011/08/29/wp-document-revisions-document-management-version-control-wordpress/
 Description: A document management and version control plugin for WordPress that allows teams of any size to collaboratively edit files and manage their workflow.
-Version: 4.0.7
+Version: 4.1.0
 Requires at least: 5.0
 Requires PHP: 7.4
 Author: Ben Balter
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  *  @copyright 2011-2025
  *  @license GPL-3.0-or-later
- *  @version 4.0.7
+ *  @version 4.1.0
  *  @package WP_Document_Revisions
  *  @author Ben Balter <ben@balter.com>
  */
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // parsed by WordPress from the file header itself and must remain literal; this
 // constant is the canonical value for runtime PHP code (cache busters, etc.).
 if ( ! defined( 'WPDR_VERSION' ) ) {
-	define( 'WPDR_VERSION', '4.0.7' );
+	define( 'WPDR_VERSION', '4.1.0' );
 }
 
 // Composer autoloader for production dependencies.


### PR DESCRIPTION
## Summary

User-visible version bump for the 4.1.0 release, which packages the 12-phase #514 text extraction + AI summary work.

The implementation is already on `main` (PRs #515 → #529); this PR just updates the release-metadata files so a wordpress.org deploy of `main` will publish as 4.1.0 instead of 4.0.7.

## What's bumped

| File | Field | From | To |
|---|---|---|---|
| `wp-document-revisions.php` | `Version:` header | 4.0.7 | 4.1.0 |
| `wp-document-revisions.php` | `@version` docblock | 4.0.7 | 4.1.0 |
| `wp-document-revisions.php` | `WPDR_VERSION` constant | 4.0.7 | 4.1.0 |
| `docs/header.md` | `Stable tag:` | 4.0.7 | 4.1.0 |
| `readme.txt` | `Stable tag:` (regenerated from header.md) | 4.0.7 | 4.1.0 |

## What's added

- `docs/changelog.md`: new `### 4.1.0` entry with eight bullets summarising the feature surface.
- `readme.txt`: matching `= 4.1.0 =` Changelog section (regenerated from changelog.md by the build-readme workflow; included here so the rendered output is reviewable inline).
- `docs/features.md`: six new feature bullets that **phase 13 added to `readme.txt` directly but not to features.md** — the next `script/build-readme` run would have stripped them from `readme.txt`. Fixed here so the two files agree.

## What's NOT bumped

- `Tested up to: 6.9` — unchanged. Bumping requires actual testing on a newer WP build, which is a release-management decision not driven by this feature work.

## Related

- Closes #514 (will be closed via separate comment summarising the audit).
- Supersedes #530 (the auto-generated "Update README" PR — once this merges, the next workflow run will produce an empty diff against the regenerated readme.txt).
- Tracking issue for deferred follow-ups: #531.

## Test plan

- [ ] CI green (PHPCS, PHPStan, PHPUnit, Jest, build-readme parity check)
- [ ] Manual: render the updated `readme.txt` against the wordpress.org parser (or check via the local `wp plugin check`) and confirm it parses cleanly
- [ ] Manual: confirm `WPDR_VERSION` resolves to `'4.1.0'` at runtime after install
- [ ] Manual: deploy the resulting artifact to a staging site, install/activate, verify the admin badge shows 4.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)