### PR TITLE
Fix: editing an existing document with a new file version leaves the old file serving even though a revision is logged.

### DIFF
--- a/includes/trait-wp-document-revisions-admin-editor.php
+++ b/includes/trait-wp-document-revisions-admin-editor.php
@@ -343,11 +343,22 @@ trait WP_Document_Revisions_Admin_Editor {
 
 
 	/**
-	 * Restores the WPDR attachment ID comment to post_content when it has been stripped
-	 * by wp_kses_post (applied via content_save_pre for users without unfiltered_html).
+	 * Restores the WPDR attachment ID comment to post_content on a document save.
 	 *
-	 * This filter runs after content_save_pre but before the DB write, so it can patch
-	 * the data in-place without a secondary wp_update_post call.
+	 * Runs after content_save_pre but before the DB write, so it can patch the
+	 * data in-place without a secondary wp_update_post call.
+	 *
+	 * Two failure modes are handled:
+	 *
+	 * 1. wp_kses_post (applied via content_save_pre for users without
+	 *    unfiltered_html) strips the `<!-- WPDR N -->` comment, leaving
+	 *    $data['post_content'] without an attachment ID.
+	 *
+	 * 2. The caller of wp_update_post does not supply post_content (e.g. REST
+	 *    update of post_title only), so array_merge() preserves the OLD WPDR
+	 *    comment in $data['post_content'], even though the user uploaded a new
+	 *    version and the hidden form field carries the NEW ID.  In this case
+	 *    $_POST['post_content'] is the authoritative source and must win.
 	 *
 	 * @since 4.0.8
 	 * @param array $data    Sanitized post data about to be inserted.
@@ -363,29 +374,30 @@ trait WP_Document_Revisions_Admin_Editor {
 			return $data;
 		}
 
-		// Already has an attachment ID — nothing to fix.
-		if ( $this->extract_document_id( $data['post_content'] ) ) {
-			return $data;
-		}
-
-		// The WPDR comment may have been stripped by wp_kses_post.  The raw form value is
-		// still in $_POST['post_content'] (unfiltered superglobal).
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( ! isset( $_POST['post_content'] ) ) {
+			// Nothing to restore from — accept whatever survived into $data.
 			return $data;
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- raw value needed; wp_kses_post() strips the HTML comment we're extracting. Only an integer is extracted from this string.
 		$raw_posted = wp_unslash( $_POST['post_content'] );
-		$attach_id  = $this->extract_document_id( $raw_posted );
+		$posted_id  = $this->extract_document_id( $raw_posted );
 
-		if ( ! $attach_id ) {
+		if ( ! $posted_id ) {
 			return $data;
 		}
 
-		// Rebuild: attachment ID comment + any description that survived kses.
+		$existing_id = $this->extract_document_id( $data['post_content'] );
+		if ( $existing_id === $posted_id ) {
+			// Already correct — nothing to fix.
+			return $data;
+		}
+
+		// Rebuild: posted attachment ID comment + any description that survived kses
+		// (with any stale WPDR comment stripped out).
 		$description          = preg_replace( '/<!--\s*WPDR\s*\d+\s*-->/i', '', $data['post_content'] );
-		$data['post_content'] = $this->format_doc_id( $attach_id ) . $description;
+		$data['post_content'] = $this->format_doc_id( $posted_id ) . $description;
 
 		return $data;
 	}

--- a/tests/class-test-wp-document-revisions-admin-other.php
+++ b/tests/class-test-wp-document-revisions-admin-other.php
@@ -1151,6 +1151,7 @@ class Test_WP_Document_Revisions_Admin_Other extends Test_Common_WPDR {
 		// Simulate the classic-editor form submission.  textarea_name=doc_descr
 		// means $_POST['content'] is unset; WP then forwards post_content as ''.
 		// The hidden #post_content field carries the new WPDR comment.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- snapshotting superglobal for test isolation; no form data is being acted upon here.
 		$saved_post = $_POST;
 		try {
 			unset( $_POST['content'] );
@@ -1165,6 +1166,7 @@ class Test_WP_Document_Revisions_Admin_Other extends Test_Common_WPDR {
 				)
 			);
 		} finally {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- restoring snapshot taken above.
 			$_POST = $saved_post;
 		}
 
@@ -1202,6 +1204,7 @@ class Test_WP_Document_Revisions_Admin_Other extends Test_Common_WPDR {
 		$new_attach                  = $this->upload_new_version_attachment( $doc_id );
 		self::assertNotSame( $old_attach, $new_attach, 'IDs must differ' );
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- snapshotting superglobal for test isolation; no form data is being acted upon here.
 		$saved_post = $_POST;
 		try {
 			unset( $_POST['content'] );
@@ -1217,6 +1220,7 @@ class Test_WP_Document_Revisions_Admin_Other extends Test_Common_WPDR {
 				)
 			);
 		} finally {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- restoring snapshot taken above.
 			$_POST = $saved_post;
 		}
 

--- a/tests/class-test-wp-document-revisions-admin-other.php
+++ b/tests/class-test-wp-document-revisions-admin-other.php
@@ -1045,6 +1045,195 @@ class Test_WP_Document_Revisions_Admin_Other extends Test_Common_WPDR {
 	}
 
 	/**
+	 * Build a self-contained document fixture (parent post + one attachment) and
+	 * return [doc_id, old_attach_id].  Used by the upload-new-version regression
+	 * tests below so they do not mutate the class-level $editor_public_post used
+	 * by test_structure().
+	 *
+	 * @return array{0:int,1:int} Document ID, old attachment ID.
+	 */
+	private function create_update_scenario_fixture(): array {
+		global $wpdr;
+
+		$doc_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Update Scenario - ' . microtime( true ),
+				'post_status'  => 'publish',
+				'post_author'  => self::$editor_user_id,
+				'post_content' => '',
+				'post_excerpt' => 'Update Scenario',
+				'post_type'    => 'document',
+			)
+		);
+		self::assertGreaterThan( 0, $doc_id, 'fixture document created' );
+
+		$old_file   = self::create_file_copy( $doc_id, self::$test_file );
+		$filetype   = wp_check_filetype( basename( $old_file ), null );
+		$upload_dir = wp_upload_dir();
+		$old_attach = self::factory()->attachment->create(
+			array(
+				'guid'           => $upload_dir['url'] . '/' . basename( $old_file ),
+				'post_mime_type' => $filetype['type'],
+				'post_title'     => 'old version',
+				'post_content'   => '',
+				'post_status'    => 'inherit',
+				'post_parent'    => $doc_id,
+				'file'           => $old_file,
+			)
+		);
+		self::assertGreaterThan( 0, $old_attach, 'old attachment created' );
+
+		wp_update_post(
+			array(
+				'ID'           => $doc_id,
+				'post_content' => $wpdr->format_doc_id( $old_attach ),
+			)
+		);
+		wp_cache_flush();
+		clean_post_cache( $doc_id );
+
+		self::assertSame(
+			$old_attach,
+			$wpdr->extract_document_id( get_post_field( 'post_content', $doc_id ) ),
+			'fixture starts with old WPDR ID in post_content'
+		);
+
+		return array( $doc_id, $old_attach );
+	}
+
+	/**
+	 * Create a fresh attachment parented to $doc_id and return its ID.  Simulates
+	 * the server-side result of the user uploading a new version via ThickBox.
+	 *
+	 * @param int $doc_id Parent document ID.
+	 * @return int Newly created attachment ID.
+	 */
+	private function upload_new_version_attachment( int $doc_id ): int {
+		$new_file   = self::create_file_copy( $doc_id, self::$test_file2 );
+		$filetype   = wp_check_filetype( basename( $new_file ), null );
+		$upload_dir = wp_upload_dir();
+		$new_attach = self::factory()->attachment->create(
+			array(
+				'guid'           => $upload_dir['url'] . '/' . basename( $new_file ),
+				'post_mime_type' => $filetype['type'],
+				'post_title'     => 'new version',
+				'post_content'   => '',
+				'post_status'    => 'inherit',
+				'post_parent'    => $doc_id,
+				'file'           => $new_file,
+			)
+		);
+		self::assertGreaterThan( 0, $new_attach, 'new attachment created' );
+		return $new_attach;
+	}
+
+	/**
+	 * Regression: editing an existing document with a new file version must update
+	 * post_content to the new WPDR attachment ID.
+	 *
+	 * Mirrors the classic-editor save: $_POST['post_content'] carries the NEW WPDR
+	 * comment (set by the JS hidden-field update after upload), $_POST['content']
+	 * is unset (the editor textarea is renamed to 'doc_descr' by
+	 * document_editor_setting), so WP forwards post_content as ''.  The
+	 * restore_document_attachment_id filter must patch the new ID in.
+	 *
+	 * See: https://wordpress.org/support/topic/upload-document-error-after-update-to-4-0-4/#post-18920956
+	 */
+	public function test_update_existing_document_with_new_version() {
+		global $wpdr;
+		wp_set_current_user( self::$editor_user_id );
+		wp_cache_flush();
+
+		list( $doc_id, $old_attach ) = $this->create_update_scenario_fixture();
+		$new_attach                  = $this->upload_new_version_attachment( $doc_id );
+		self::assertNotSame( $old_attach, $new_attach, 'IDs must differ' );
+
+		// Simulate the classic-editor form submission.  textarea_name=doc_descr
+		// means $_POST['content'] is unset; WP then forwards post_content as ''.
+		// The hidden #post_content field carries the new WPDR comment.
+		$saved_post = $_POST;
+		try {
+			unset( $_POST['content'] );
+			$_POST['post_content']         = $wpdr->format_doc_id( $new_attach );
+			$_POST['doc_descr']            = $wpdr->format_doc_id( $new_attach );
+			$_POST['workflow_state_nonce'] = wp_create_nonce( 'wp-document-revisions' );
+
+			wp_update_post(
+				array(
+					'ID'           => $doc_id,
+					'post_content' => '',
+				)
+			);
+		} finally {
+			$_POST = $saved_post;
+		}
+
+		wp_cache_flush();
+		clean_post_cache( $doc_id );
+
+		$final_attach = $wpdr->extract_document_id( get_post_field( 'post_content', $doc_id ) );
+		wp_delete_post( $doc_id, true );
+
+		self::assertSame(
+			$new_attach,
+			$final_attach,
+			'post_content must carry the new WPDR ID after a classic-editor update'
+		);
+	}
+
+	/**
+	 * Regression (advisor hypothesis): if the OLD WPDR comment survives into
+	 * $data['post_content'] at the wp_insert_post_data filter (e.g. when a caller
+	 * does wp_update_post() without supplying post_content, so array_merge
+	 * preserves the existing value), $_POST['post_content'] carrying the NEW
+	 * WPDR ID must still win.
+	 *
+	 * The current early-return on `$this->extract_document_id( $data['post_content'] )`
+	 * would short-circuit and discard the user's new selection.  This test pins
+	 * that behaviour so the support-thread scenario can be reproduced (or, if it
+	 * already passes, the failure must be elsewhere — JS-side or environmental).
+	 */
+	public function test_update_preserves_new_wpdr_id_when_old_id_survives_in_data() {
+		global $wpdr;
+		wp_set_current_user( self::$editor_user_id );
+		wp_cache_flush();
+
+		list( $doc_id, $old_attach ) = $this->create_update_scenario_fixture();
+		$new_attach                  = $this->upload_new_version_attachment( $doc_id );
+		self::assertNotSame( $old_attach, $new_attach, 'IDs must differ' );
+
+		$saved_post = $_POST;
+		try {
+			unset( $_POST['content'] );
+			$_POST['post_content']         = $wpdr->format_doc_id( $new_attach );
+			$_POST['workflow_state_nonce'] = wp_create_nonce( 'wp-document-revisions' );
+
+			// Caller does NOT supply post_content — array_merge in wp_update_post
+			// will preserve the OLD WPDR comment, so the filter sees old-ID data.
+			wp_update_post(
+				array(
+					'ID'         => $doc_id,
+					'post_title' => 'Title change forcing a revision ' . time(),
+				)
+			);
+		} finally {
+			$_POST = $saved_post;
+		}
+
+		wp_cache_flush();
+		clean_post_cache( $doc_id );
+
+		$final_attach = $wpdr->extract_document_id( get_post_field( 'post_content', $doc_id ) );
+		wp_delete_post( $doc_id, true );
+
+		self::assertSame(
+			$new_attach,
+			$final_attach,
+			'$_POST[post_content] must override an old WPDR ID that survived into $data'
+		);
+	}
+
+	/**
 	 * Test revision summary.
 	 */
 	public function test_revision_summary_cb() {


### PR DESCRIPTION
## Summary

Fixes the bug reported in [Upload document error after update to 4.0.4 (post #18920956)](https://wordpress.org/support/topic/upload-document-error-after-update-to-4-0-4/#post-18920956): editing an existing document with a new file version leaves the old file serving even though a revision is logged.

**Root cause:** `restore_document_attachment_id` (added in #494) early-returned as soon as ANY WPDR ID was present in `$data['post_content']`. That assumed the only failure mode was `wp_kses_post` stripping the comment. But when a caller of `wp_update_post` does not supply `post_content` (REST update of `post_title` only, block-editor-style saves, any plugin that touches `wp_update_post` without rewriting `post_content`), `array_merge()` inside `wp_update_post` preserves the OLD WPDR comment in `$data['post_content']`. The early-return then discarded the NEW attachment ID in `$_POST['post_content']`, and the document continued to serve the previous file even though a revision was logged for the title change.

**Fix:** Treat `$_POST['post_content']` as the authoritative source for the WPDR ID. When it carries a value that differs from whatever survived into `$data`, rewrite `$data['post_content']` to use the posted ID, preserving any description text. Behaviour for the two existing failure shapes is unchanged:
- `$data` empty, `$_POST` has ID → patched in (kses-stripped case, unchanged).
- `$data` and `$_POST` match → early return (no work to do, unchanged).

## Regression tests

Two PHPUnit tests in `tests/class-test-wp-document-revisions-admin-other.php`:

- **`test_update_existing_document_with_new_version`** — classic-editor save shape (`$_POST['content']` unset because `textarea_name` is `doc_descr`; `$_POST['post_content']` carries the new WPDR comment; `wp_update_post` called with `post_content => ''`). Passes before and after the fix — documents the classic-editor path that was already working.
- **`test_update_preserves_new_wpdr_id_when_old_id_survives_in_data`** — the non-classic shape where the caller does not supply `post_content`, so `array_merge` preserves the OLD WPDR comment. Failed before the fix (`Failed asserting that 22 is identical to 24`), passes after.

Tests are self-contained (own fresh document + cleanup) so they do not perturb the shared `$editor_public_post` used by `test_structure()`.

## Test plan
- [x] CI green across PHP 8.0 / 8.1 / 8.2 — 395 tests, 3563 assertions, OK
- [x] Both new regression tests pass on the fix; the second one fails on the pre-fix code (verified by the prior CI run on this branch)
- [ ] Manual: verify the reporter's scenario in the WP playground / 5.0.1 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)