### PR TITLE
Fix the_title TypeError from strict ?int param (#550)

### DIFF
--- a/includes/trait-wp-document-revisions-query.php
+++ b/includes/trait-wp-document-revisions-query.php
@@ -236,12 +236,15 @@ trait WP_Document_Revisions_Query {
 	 *
 	 * @since 1.0
 	 * @param string $title   the title.
-	 * @param int    $post_id The ID of the post for which the title is being generated.
+	 * @param mixed  $post_id The ID of the post for which the title is being generated.
 	 * @return string the title possibly with the revision number
 	 */
-	public function add_revision_num_to_title( string $title, ?int $post_id = null ): string {
-		// If a post ID is not provided, do not attempt to filter the title.
-		if ( is_null( $post_id ) ) {
+	public function add_revision_num_to_title( string $title, $post_id = null ): string {
+		// If a usable post ID is not provided, do not attempt to filter the title.
+		// The `the_title` filter can be called with non-integer values (e.g. an empty
+		// string), so accept any type and guard with is_numeric() rather than a strict
+		// `?int` hint, which would throw a TypeError and crash the request.
+		if ( ! is_numeric( $post_id ) ) {
 			return $title;
 		}
 


### PR DESCRIPTION
## Summary

`add_revision_num_to_title()` is hooked to WordPress's `the_title` filter. That filter can be invoked with a non-integer post ID (e.g. an empty string), but the method declares a strict `?int $post_id` hint, so PHP throws an uncaught `TypeError` and the request crashes.

This relaxes the parameter to accept any type and guards with `is_numeric()` before calling `get_post()`. Behaviour for valid integer IDs and `null` is unchanged; unexpected input now short-circuits to the unmodified title instead of fataling.

## Context

This is one of several focused PRs extracting the independently-valuable, low-risk fixes from the bundled #547 so they can land (and be CI-verified) on their own. Maps to issue #550.

## Test plan

- [ ] CI green (PHP matrix + PHPCS/PHPStan)
- Call `apply_filters( 'the_title', 'x', '' )` (non-numeric ID) — no TypeError, returns title unchanged.
- Existing revision-title behaviour for real document IDs unchanged.

## Notes

- Code-only by design (no changelog churn) to keep the split PRs conflict-free; a consolidated changelog entry can be added when cutting the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)