### PR TITLE
Add document_no_document_response_code filter (#453)

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -85,6 +85,17 @@ In: trait-wp-document-revisions-revisions.php
 
 Filters the lost lock document email text.
 
+## Filter document_no_document_response_code
+
+In: trait-wp-document-revisions-file-handler.php
+
+Filters the HTTP response code returned when a document or revision file cannot be served (default 403).
+
+> [!WARNING]
+> Changing the response code from the default of 403 may introduce an existence vulnerability.
+> Comparing a 403 (file exists but not authorized) against a 404 (file not found) lets an
+> unauthorized visitor probe whether a given document exists.
+
 ## Filter document_output_sent_is_ok
 
 In: trait-wp-document-revisions-file-handler.php

--- a/includes/trait-wp-document-revisions-file-handler.php
+++ b/includes/trait-wp-document-revisions-file-handler.php
@@ -55,7 +55,7 @@ trait WP_Document_Revisions_File_Handler {
 		 *
 		 * @param int $response_code The default response code (403).
 		 */
-		$response_code = absint( apply_filters( 'document_no_document_response_code', 403 ) );
+		$response_code = apply_filters( 'document_no_document_response_code', 403 );
 
 		// if there's not a post revision given, default to the latest.
 		if ( ! $version ) {
@@ -65,7 +65,7 @@ trait WP_Document_Revisions_File_Handler {
 				wp_die(
 					esc_html__( 'No document file is attached.', 'wp-document-revisions' ),
 					null,
-					array( 'response' => $response_code )
+					array( 'response' => absint( $response_code ) )
 				);
 				// for unit testing.
 				$wp_query->is_404 = true;
@@ -99,7 +99,7 @@ trait WP_Document_Revisions_File_Handler {
 			wp_die(
 				esc_html( $msg ),
 				null,
-				array( 'response' => $response_code )
+				array( 'response' => absint( $response_code ) )
 			);
 			// for unit testing.
 			$wp_query->is_404 = true;

--- a/includes/trait-wp-document-revisions-file-handler.php
+++ b/includes/trait-wp-document-revisions-file-handler.php
@@ -44,6 +44,19 @@ trait WP_Document_Revisions_File_Handler {
 		// grab the post revision if any.
 		$version = get_query_var( 'revision' );
 
+		/**
+		 * Filters the HTTP response code returned when a document (or revision) file cannot be served.
+		 *
+		 * Defaults to 403. Note that changing this to 404 can leak the existence of documents:
+		 * comparing a 403 (file exists but not authorized) against a 404 (file not found) lets an
+		 * unauthorized visitor probe whether a given document exists.
+		 *
+		 * @since 5.0.1
+		 *
+		 * @param int $response_code The default response code (403).
+		 */
+		$response_code = absint( apply_filters( 'document_no_document_response_code', 403 ) );
+
 		// if there's not a post revision given, default to the latest.
 		if ( ! $version ) {
 			$revn = $this->get_latest_revision( $post->ID );
@@ -52,7 +65,7 @@ trait WP_Document_Revisions_File_Handler {
 				wp_die(
 					esc_html__( 'No document file is attached.', 'wp-document-revisions' ),
 					null,
-					array( 'response' => 403 )
+					array( 'response' => $response_code )
 				);
 				// for unit testing.
 				$wp_query->is_404 = true;
@@ -86,7 +99,7 @@ trait WP_Document_Revisions_File_Handler {
 			wp_die(
 				esc_html( $msg ),
 				null,
-				array( 'response' => 403 )
+				array( 'response' => $response_code )
 			);
 			// for unit testing.
 			$wp_query->is_404 = true;


### PR DESCRIPTION
## Summary

Adds a `document_no_document_response_code` filter so sites can change the HTTP status returned when a document/revision file cannot be served. Default is the existing **403**.

The filter is applied to the two "no document file is attached" / "document is not available" `wp_die()` paths in `serve_file()`. The **authorization-failure** `wp_die()` is intentionally left hard-coded at 403.

## Security note

Documented in `docs/filters.md` with a warning: changing the code (e.g. to 404) can introduce an existence-disclosure vector — comparing 403 (exists, not authorized) vs 404 (not found) lets an unauthorized visitor probe whether a document exists. That's why only the "file genuinely missing" paths are filterable and the auth path is not.

## Context

One of several focused PRs extracting independently-valuable changes from the bundled #547. Maps to issue #453.

## Test plan

- [ ] CI green
- Request a document with no attached file → 403 by default.
- `add_filter( 'document_no_document_response_code', fn() => 404 )` → those paths return 404; authorization failures still return 403.

## Notes

- Code + filter docs only; consolidated changelog entry deferred to release to keep the split PRs conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)