### PR TITLE
Accept HTML-entity-encoded ugly permalink in guid validation (#549)

### DIFF
--- a/includes/class-wp-document-revisions-validate-structure.php
+++ b/includes/class-wp-document-revisions-validate-structure.php
@@ -767,7 +767,7 @@ class WP_Document_Revisions_Validate_Structure {
 	 * @param string $post_date   post date field.
 	 * @param string $post_name   post name field.
 	 * @param string $guid        post guid field.
-	 * @return array|false
+	 * @return array|bool
 	 */
 	private static function validate_guid( $doc_id, $attach_id, string $post_status, string $post_date, string $post_name, string $guid ) {
 		$msg_09 = esc_html__( 'The guid is not the expected "ugly" permalink', 'wp-document-revisions' );
@@ -780,11 +780,12 @@ class WP_Document_Revisions_Validate_Structure {
 		$msg_12 = esc_html__( 'The guid does not reflect the complete document permalink.', 'wp-document-revisions' );
 		global $wp_rewrite;
 		$permalink1 = site_url( '?post_type=document&p=' . (string) $doc_id );
-		$permalink2 = str_replace( '/?', '?', $permalink1 );
+		// `&` may be stored HTML-entity-encoded in the guid, so accept that variant too.
+		$permalink2 = str_replace( '&p=', '&#038;p=', $permalink1 );
+		$permalink3 = str_replace( '/?', '?', $permalink1 );
+		$in_ugly    = in_array( $guid, array( $permalink1, $permalink2, $permalink3 ), true );
 		if ( '' === $wp_rewrite->permalink_structure || in_array( $post_status, array( 'pending', 'draft' ), true ) ) {
-			$permalink1 = site_url( '?post_type=document&p=' . $doc_id );
-			$permalink2 = str_replace( '/?', '?', $permalink1 );
-			if ( $guid !== $permalink1 && $guid !== $permalink2 ) {
+			if ( ! $in_ugly ) {
 				return array(
 					'code'  => 9,
 					'error' => 0,
@@ -829,7 +830,7 @@ class WP_Document_Revisions_Validate_Structure {
 					'parm'  => $doc_id,
 				);
 			}
-		} elseif ( $guid !== $permalink1 && $guid !== $permalink2 ) {
+		} elseif ( ! $in_ugly ) {
 			// Ugly one is accepable as it is unique.
 
 			if ( '' !== $year_mth ) {
@@ -846,6 +847,9 @@ class WP_Document_Revisions_Validate_Structure {
 				'parm'  => $doc_id,
 			);
 		}
+
+		// guid validated with no problem found.
+		return false;
 	}
 
 	/**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -217,24 +217,6 @@ parameters:
 			path: includes/class-wp-document-revisions-validate-structure.php
 
 		-
-			message: '#^Method WP_Document_Revisions_Validate_Structure\:\:validate_guid\(\) never returns false so it can be removed from the return type\.$#'
-			identifier: return.unusedType
-			count: 1
-			path: includes/class-wp-document-revisions-validate-structure.php
-
-		-
-			message: '#^Method WP_Document_Revisions_Validate_Structure\:\:validate_guid\(\) should return array\|false but return statement is missing\.$#'
-			identifier: return.missing
-			count: 2
-			path: includes/class-wp-document-revisions-validate-structure.php
-
-		-
-			message: '#^Method WP_Document_Revisions_Validate_Structure\:\:validate_guid\(\) should return array\|false but returns true\.$#'
-			identifier: return.type
-			count: 1
-			path: includes/class-wp-document-revisions-validate-structure.php
-
-		-
 			message: '#^Parameter \#1 \$post_id of function get_post_meta expects int, string given\.$#'
 			identifier: argument.type
 			count: 1


### PR DESCRIPTION
## Summary

The document structure validator raised a false-positive *"guid is not the expected 'ugly' permalink"* (code 9 / code 10) when the stored guid encoded the ampersand as `&#038;` — e.g. `?post_type=document&#038;p=123`. That's a legitimate, unique form of the ugly permalink and should validate.

This builds the accepted set from three equivalent forms (plain `&`, HTML-entity `&#038;`, and the leading-`/?`-stripped variant) and tests membership once via `$in_ugly`, replacing the two duplicated `$guid !== $permalink1 && $guid !== $permalink2` comparisons.

It also adds an explicit `return false` to the "validated, no problem" path — the method previously fell through to an implicit `null` return — and corrects the docblock to `@return array|bool`. The sole caller checks `is_array( $test )`, so non-array returns are handled identically; this is behaviour-preserving.

## Context

One of several focused PRs extracting independently-valuable fixes from the bundled #547. Maps to issue #549.

## Test plan

- [ ] CI green
- A document whose guid uses `&#038;p=` no longer reports a code 9/10 structure error.
- Plain `&p=` and `/?`-stripped guids still validate; genuinely malformed guids still flag.

## Notes

- Code-only; consolidated changelog entry deferred to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)