### PR TITLE
Harden REST attachment response and fix edit-context revision route (#554)

### DIFF
--- a/includes/class-wp-document-revisions-manage-rest.php
+++ b/includes/class-wp-document-revisions-manage-rest.php
@@ -285,6 +285,22 @@ class WP_Document_Revisions_Manage_Rest {
 		// For non-editors, strip all media details to prevent file path leakage.
 		$response->data['media_details'] = new stdClass();
 
+		// Also protect the file name, size and mime type, which can leak the
+		// (hashed) filename, reveal file size, or fingerprint the document type.
+		$response->data['mime_type'] = $protected;
+		if ( isset( $response->data['filename'] ) ) {
+			$response->data['filename'] = $protected;
+		}
+		if ( isset( $response->data['filesize'] ) ) {
+			$response->data['filesize'] = $protected;
+		}
+
+		// If the user cannot read the document at all, also drop the link back to
+		// the parent document so the relationship can't be enumerated.
+		if ( ! apply_filters( 'document_read_uses_read', true ) && ! current_user_can( 'read_document', $parent ) ) {
+			$response->remove_link( 'https://api.w.org/attached-to' );
+		}
+
 		return $response;
 	}
 

--- a/includes/class-wp-document-revisions-manage-rest.php
+++ b/includes/class-wp-document-revisions-manage-rest.php
@@ -98,7 +98,12 @@ class WP_Document_Revisions_Manage_Rest {
 
 		// Check for valid document editing.
 		if ( 'edit' === $request['context'] ) {
-			if ( isset( $params['id'] ) && current_user_can( 'edit_post', $params['id'] ) ) {
+			// Standard route for a document (identified by id).
+			if ( isset( $params['id'] ) && current_user_can( 'edit_document', $params['id'] ) ) {
+				return $response;
+			}
+			// WP-standard route for revisions and autosaves (identified by parent).
+			if ( isset( $params['parent'] ) && current_user_can( 'edit_document', $params['parent'] ) ) {
 				return $response;
 			}
 			return new WP_Error(


### PR DESCRIPTION
## Summary

Two related REST fixes under #554, both extracted from #547:

**1. Harden the attachment response for non-editors** (`doc_clean_attachment`). In addition to the existing protection (slug, source_url, title, description, guid, link, media_details), also:
- redact the top-level `mime_type` (always present) so a non-editor can't fingerprint the file type;
- redact `filename` / `filesize` when present (e.g. exposed by an extension);
- remove the `api.w.org/attached-to` link when the site requires `read_documents` (`document_read_uses_read` = false) and the user lacks `read_document` on the parent, so the attachment→document relationship can't be enumerated.

Editors of the document still get the full response (early `return` unchanged).

**2. Allow the parent-based revisions/autosaves route in edit context** (`document_validation`). The WP-standard revisions and autosaves routes are identified by `parent` (the document id), not `id`. The previous edit-context check only allowed `id`, so those routes were rejected with `rest_forbidden_context` — which broke editing via them (surfaced by @NeilWJames testing the block-editor flow). Now both `id`- and `parent`-based routes are allowed, gated on `edit_document`. The `id` branch also moves from `edit_post` to the explicit `edit_document` primitive (behaviour-preserving — `edit_post` maps to `edit_document` via `map_meta_cap`).

## Context

One of several focused PRs extracting independently-valuable changes from the bundled #547. Maps to issue #554.

## Test plan

- [ ] CI green
- Non-editor fetch of a document attachment via REST → `mime_type`/`filename`/`filesize` are `<!-- protected -->`, `media_details` empty; with `document_read_uses_read` false and no `read_document`, the `attached-to` link is absent.
- Editor of the document → full response.
- Edit a document's revision/autosave via the `parent`-based REST route as a user who can `edit_document` the parent → no longer rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)