### PR TITLE
Fix E2E: pin @wordpress/e2e-test-utils-playwright to 1.46.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,11 @@ updates:
       ignore:
           - dependency-name: 'jest-environment-jsdom'
             update-types: ['version-update:semver-major']
+          # @wordpress/e2e-test-utils-playwright 1.47.0+ points its package
+          # `exports` at raw TypeScript (src/index.ts) with no compiled-JS
+          # condition. Under Node 22's default type stripping, requiring a
+          # .ts file from node_modules is unsupported, so every E2E spec
+          # fails to load. Hold at 1.46.0 (last version shipping build/
+          # index.cjs) until upstream restores a compiled entry point.
+          - dependency-name: '@wordpress/e2e-test-utils-playwright'
+            versions: ['>=1.47.0']

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@axe-core/playwright": "^4.11.1",
         "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
-        "@wordpress/e2e-test-utils-playwright": "^1.47.0",
+        "@wordpress/e2e-test-utils-playwright": "1.46.0",
         "@wordpress/env": "^11.8.0",
         "@wordpress/scripts": "^32.4.0",
         "jest": "^30.3.0",
@@ -8773,9 +8773,9 @@
       }
     },
     "node_modules/@wordpress/e2e-test-utils-playwright": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.48.0.tgz",
-      "integrity": "sha512-jLzobHMQha8ZUHkRhl4OJVCkk26jTVqbhN5hFpQruVTETMI3Z1PFJZH1DFAumJKKAIociVMVeH2MDD8XVp72ww==",
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.46.0.tgz",
+      "integrity": "sha512-Bls5BGRNda0Oo4biTZ/KIwO8iHBeovvfWNfrPXReIsrW1td1UqXw2Z9l0/LaP3euJZFNom2QExHCOba+8eN5lQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -9363,6 +9363,28 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/@wordpress/e2e-test-utils-playwright": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.48.0.tgz",
+      "integrity": "sha512-jLzobHMQha8ZUHkRhl4OJVCkk26jTVqbhN5hFpQruVTETMI3Z1PFJZH1DFAumJKKAIociVMVeH2MDD8XVp72ww==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "change-case": "^4.1.2",
+        "get-port": "^5.1.1",
+        "lighthouse": "^12.2.2",
+        "mime": "^3.0.0",
+        "web-vitals": "^4.2.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1",
+        "@types/node": "^20.17.10"
       }
     },
     "node_modules/@wordpress/scripts/node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@axe-core/playwright": "^4.11.1",
     "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
-    "@wordpress/e2e-test-utils-playwright": "^1.47.0",
+    "@wordpress/e2e-test-utils-playwright": "1.46.0",
     "@wordpress/env": "^11.8.0",
     "@wordpress/scripts": "^32.4.0",
     "jest": "^30.3.0",


### PR DESCRIPTION
## Summary

E2E is red on `main` (and therefore on every open PR, including #557–#560). The job fails at spec **load** time — before any test runs:

```
Error: Stripping types is currently unsupported for files under node_modules,
for ".../@wordpress/e2e-test-utils-playwright/src/index.ts"
   at accessibility/blocks.spec.js:7
>  7 | const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
```

### Root cause

From **1.47.0**, `@wordpress/e2e-test-utils-playwright` changed its package `exports` to point `"default"` at raw TypeScript (`./src/index.ts`) with no compiled-JS condition. Our lockfile had resolved to **1.48.0**. CI runs on **Node 22**, which strips TypeScript types by default but **refuses to do so for files under `node_modules`** — a hard restriction with no override flag. So every `require('@wordpress/e2e-test-utils-playwright')` throws at load.

This is the same breakage the bundled #547 was wrestling with ("Set Node not to strip types", "Convert to ESM", playwright pinning).

### Fix

Pin to **1.46.0** — the last release whose `main` is `./build/index.cjs` (compiled CommonJS) — so Node never encounters a `.ts` file.

- Peer deps unchanged: `@playwright/test: >=1` (we have ^1.59.1), `@types/node: ^20.17.10`.
- The 1.48.0 copy stays nested under `@wordpress/scripts`'s own `node_modules` and is **not** loaded by our specs (they resolve the top-level 1.46.0).
- Added a Dependabot `ignore` for `>=1.47.0` so the bump can't silently reintroduce the break until upstream restores a compiled entry point.

## Why a separate PR

The failure is shared infrastructure, not specific to any one fix. Landing this first makes `main` green; the four review-split PRs (#557–#560) go green once rebased on it.

## Test plan

- [ ] E2E job loads specs and runs (no "Stripping types" error).
- [ ] `npm ci` resolves top-level `@wordpress/e2e-test-utils-playwright` to 1.46.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)