### PR TITLE
Fix Playground live-preview spurious capability error (#552)

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,7 +1,8 @@
 {
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"landingPage": "/wp-admin/edit.php?post_type=document",
 	"preferredVersions": {
-		"php": "8.0",
+		"php": "8.3",
 		"wp": "latest"
 	},
 	"features": {
@@ -9,8 +10,13 @@
 	},
 	"steps": [
 		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		},
+		{
 			"step": "installPlugin",
-			"pluginZipFile": {
+			"pluginData": {
 				"resource": "wordpress.org/plugins",
 				"slug": "wp-document-revisions"
 			},
@@ -19,8 +25,12 @@
 			}
 		},
 		{
+			"step": "runPHP",
+			"code": "<?php require '/wordpress/wp-load.php'; $user_id = wp_create_user('editor', 'password', 'editor@localhost'); (new WP_User($user_id))->set_role('editor');"
+		},
+		{
 			"step": "login",
-			"username": "admin",
+			"username": "editor",
 			"password": "password"
 		}
 	]


### PR DESCRIPTION
## Summary

Fixes #552. The WordPress Playground live preview logs in as **admin**, who is shown a spurious *"you do not have the edit_documents capability"* notice on the documents screen — even though the menu, create, and edit all work. Logging in as an **editor** (who has the document capabilities cleanly) avoids it.

This blueprint-only change:
- creates a dedicated `editor` user via a `runPHP` step and logs in as that user after install;
- bumps the preview PHP from **8.0 → 8.3**;
- switches the `installPlugin` step from the older `pluginZipFile` key to the current **`pluginData`** form;
- adds the `$schema` reference so the blueprint validates against the Playground schema.

## Context

One of several focused PRs extracting independently-shippable pieces from the bundled #547 (per @NeilWJames, who noted #552 is a blueprint-only change). Maps to issue #552.

## Test plan

- [ ] Open the live preview (Playground) and confirm the documents screen no longer shows the `edit_documents` capability error.
- [ ] Confirm the plugin installs/activates and the editor can create a document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)