### PR TITLE
Pass through prior error responses in REST doc_clean_* filters (#554)

### DIFF
--- a/includes/class-wp-document-revisions-manage-rest.php
+++ b/includes/class-wp-document-revisions-manage-rest.php
@@ -163,11 +163,16 @@ class WP_Document_Revisions_Manage_Rest {
 	 *
 	 * @since 3.4.0
 	 *
-	 * @param WP_REST_Response $response The response object.
-	 * @param WP_Post          $post     Post object.
-	 * @param WP_REST_Request  $request  Request object.
+	 * @param WP_REST_Response|WP_Error $response The response object (or error if a prior filter set one).
+	 * @param WP_Post                   $post     Post object.
+	 * @param WP_REST_Request           $request  Request object.
 	 */
-	public function doc_clean_document( WP_REST_Response $response, WP_Post $post, WP_REST_Request $request ) {
+	public function doc_clean_document( $response, WP_Post $post, WP_REST_Request $request ) {
+		// A prior filter already produced an error response — pass it through untouched.
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
 		// is it a document.
 		if ( 'document' !== get_post_type( $post->ID ) ) {
 			return $response;
@@ -217,11 +222,16 @@ class WP_Document_Revisions_Manage_Rest {
 	 *
 	 * @since 3.4.0
 	 *
-	 * @param WP_REST_Response $response The response object.
-	 * @param WP_Post          $post     Post object.
-	 * @param WP_REST_Request  $request  Request object.
+	 * @param WP_REST_Response|WP_Error $response The response object (or error if a prior filter set one).
+	 * @param WP_Post                   $post     Post object.
+	 * @param WP_REST_Request           $request  Request object.
 	 */
-	public function doc_clean_revision( WP_REST_Response $response, WP_Post $post, WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	public function doc_clean_revision( $response, WP_Post $post, WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		// A prior filter already produced an error response — pass it through untouched.
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
 		// is it a document revision.
 		$parent = $post->post_parent;
 		if ( 0 === $parent || 'document' !== get_post_type( $parent ) ) {
@@ -252,11 +262,16 @@ class WP_Document_Revisions_Manage_Rest {
 	 *
 	 * @since 3.4.0
 	 *
-	 * @param WP_REST_Response $response The response object.
-	 * @param WP_Post          $post     Post object.
-	 * @param WP_REST_Request  $request  Request object.
+	 * @param WP_REST_Response|WP_Error $response The response object (or error if a prior filter set one).
+	 * @param WP_Post                   $post     Post object.
+	 * @param WP_REST_Request           $request  Request object.
 	 */
-	public function doc_clean_attachment( WP_REST_Response $response, WP_Post $post, WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	public function doc_clean_attachment( $response, WP_Post $post, WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		// A prior filter already produced an error response — pass it through untouched.
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
 		// is it a document attachment. (featured images have parent set to 0).
 		$parent = $post->post_parent;
 		if ( 0 < $parent && 'document' === get_post_type( $parent ) ) {


### PR DESCRIPTION
## Summary

Completes the remaining part of #554: *"If a previous filter has returned an error response then we should simply pass that on and do no other processing."*

The three `rest_prepare_{document,revision,attachment}` callbacks (`doc_clean_document`, `doc_clean_revision`, `doc_clean_attachment`) declared a strict `WP_REST_Response $response` first parameter, so if an earlier filter handed them a `WP_Error`, PHP would fatal. This relaxes the parameter to `WP_REST_Response|WP_Error` and returns early on `is_wp_error()`. Normal responses are unaffected.

## Context

Follow-up to #560, which delivered the other two parts of #554 (protecting `mime_type`/`filename`/`filesize` for non-editors, and allowing the parent-based revisions/autosaves route in edit context). Extracted from #547. With this, #554 is fully addressed and can be closed on merge.

## Test plan

- [ ] CI green (code-quality / PHPStan / PHP matrix)
- A filter that returns a `WP_Error` from `rest_prepare_document` no longer fatals; the error passes through unchanged.
- Normal document/revision/attachment REST responses are scrubbed exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)