### PR TITLE
Release 5.1.0: version bump and changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@
 
 Numbers in brackets show the issue number in https://github.com/wp-document-revisions/wp-document-revisions/issues/
 
-### 5.x.x
+### 5.1.0
 
 * Upload document files using wp.media rather than the thickbox process simplifying internal processing. (#539)
 * Extend Validation structure process to identify inaccessible document files and potentially delete them. (#551)

--- a/includes/class-wp-document-revisions-validate-structure.php
+++ b/includes/class-wp-document-revisions-validate-structure.php
@@ -814,7 +814,7 @@ class WP_Document_Revisions_Validate_Structure {
 		 * Whilst basically an on/off switch, it is called for each document.
 		 * Adding the document id allows only a segment of documents to be checked.
 		 *
-		 * @since 5.1
+		 * @since 5.1.0
 		 * @param bool $check  Whether to check for orphan records (default true).
 		 * @param ?int $doc_id Document post id.
 		 */

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: documents, document management, version control, collaboration, revisions
 Requires at least: 5.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 5.0.0
+Stable tag: 5.1.0
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -219,7 +219,7 @@ Interested in translating WP Document Revisions? You can do so [via Crowdin](htt
 
 Numbers in brackets show the issue number in https://github.com/wp-document-revisions/wp-document-revisions/issues/
 
-= 5.x.x =
+= 5.1.0 =
 
 * Upload document files using wp.media rather than the thickbox process simplifying internal processing. (#539)
 * Extend Validation structure process to identify inaccessible document files and potentially delete them. (#551)

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Document Revisions
 Plugin URI: http://ben.balter.com/2011/08/29/wp-document-revisions-document-management-version-control-wordpress/
 Description: A document management and version control plugin for WordPress that allows teams of any size to collaboratively edit files and manage their workflow.
-Version: 5.0.0
+Version: 5.1.0
 Requires at least: 5.9
 Requires PHP: 8.0
 Author: Ben Balter
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // parsed by WordPress from the file header itself and must remain literal; this
 // constant is the canonical value for runtime PHP code (cache busters, etc.).
 if ( ! defined( 'WPDR_VERSION' ) ) {
-	define( 'WPDR_VERSION', '5.0.0' );
+	define( 'WPDR_VERSION', '5.1.0' );
 }
 
 // Composer autoloader for production dependencies.


### PR DESCRIPTION
## Summary

Cuts the **5.1.0** release now that #547 and the PRs split from it have merged. A **minor, backward-compatible** release (new features + fixes, no breaking changes), so 5.0.0 → 5.1.0.

- **Version bump 5.0.0 → 5.1.0** in the plugin header, the `WPDR_VERSION` constant, and the `readme.txt` Stable tag.
- **Changelog**: promote the `5.x.x` placeholder to `5.1.0` in `docs/changelog.md` and `readme.txt`. The entries themselves landed with #547 (#539 wp.media upload, #551 orphan validation/removal + new `document_check_orphans`/`document_validate_orphans` filters, #453 `document_no_document_response_code` filter, #549 guid validation, #553 revision-log restore, #554 REST hardening, #548 revision-age fix, #550 the_title fix).
- Normalize the lone `@since 5.1` → `@since 5.1.0`.

## Notes
- `package.json` stays at `4.0.0` — it's the dev-tooling/npm version and has been intentionally decoupled from the plugin version (it was already `4.0.0` while the plugin was `5.0.0`). Happy to sync it if you'd prefer.
- No code/behavior changes here beyond the `@since` doc tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)