### PR TITLE
Bump the @version docblock tag to 5.1.0

### DIFF
--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  *  @copyright 2011-2026
  *  @license GPL-3.0-or-later
- *  @version 5.0.0
+ *  @version 5.1.0
  *  @package WP_Document_Revisions
  *  @author Ben Balter <ben@balter.com>
  */


### PR DESCRIPTION
Follow-up to the merged 5.1.0 release (#566): the plugin header `Version:`, `WPDR_VERSION`, and the readme Stable tag were bumped, but the `@version` docblock tag in the file comment was missed. Brings it in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)