### PR TITLE
Add per-revision diff REST endpoint (#531)

### DIFF
--- a/includes/class-wp-document-revisions-ai-summary-rest.php
+++ b/includes/class-wp-document-revisions-ai-summary-rest.php
@@ -14,15 +14,21 @@
  *       Marks (or un-marks) the cached summary as human-reviewed by the
  *       current user. Capability: `edit_document` on the document.
  *
+ *   GET  /wpdr/v1/documents/<doc_id>/revisions/<rev_id>/diff
+ *       Returns the unified diff between the revision and the one that
+ *       precedes it — the same change signal that drives the summary.
+ *       Capability: `read_document` on the document AND
+ *       `read_document_revisions` (revisions are more sensitive than the
+ *       current file, so this mirrors the revision-listing gate).
+ *
  * Generation itself is NOT exposed over REST — it runs on cron after
  * extraction completes (see {@see WP_Document_Revisions_AI_Summary}).
  * The capability mapping mirrors @NeilWJames's input on issue #514:
  * reading a summary is gated like reading the document file, marking
- * reviewed is gated like editing, and the per-revision diff record
- * (which would require `read_document_revisions`) is intentionally
- * not exposed in this phase.
+ * reviewed is gated like editing, and the per-revision diff record is
+ * gated like listing revisions (`read_document_revisions`).
  *
- * Phase 11 of issue #514.
+ * Phase 11 of issue #514 (diff route added as a #531 follow-up).
  *
  * @since 5.0.0
  * @package WP_Document_Revisions
@@ -89,6 +95,16 @@ class WP_Document_Revisions_AI_Summary_REST {
 				),
 			)
 		);
+		register_rest_route(
+			self::ROUTE_NAMESPACE,
+			'/documents/(?P<doc_id>\d+)/revisions/(?P<rev_id>\d+)/diff',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( __CLASS__, 'get_diff' ),
+				'permission_callback' => array( __CLASS__, 'can_read_diff' ),
+				'args'                => self::id_args(),
+			)
+		);
 	}
 
 	/**
@@ -131,6 +147,29 @@ class WP_Document_Revisions_AI_Summary_REST {
 			return new WP_Error(
 				'rest_forbidden',
 				__( 'Insufficient permission to mark this summary reviewed.', 'wp-document-revisions' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Permission callback for the diff route: caller must be able to read
+	 * the document AND have the `read_document_revisions` capability, AND
+	 * the claimed revision must be an attachment of that document.
+	 *
+	 * @param WP_REST_Request $request incoming request.
+	 * @return true|WP_Error
+	 */
+	public static function can_read_diff( WP_REST_Request $request ) {
+		$ids = self::resolve_ids( $request );
+		if ( is_wp_error( $ids ) ) {
+			return $ids;
+		}
+		if ( ! current_user_can( 'read_document', $ids['doc_id'] ) || ! current_user_can( 'read_document_revisions' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Insufficient permission to read this document revision diff.', 'wp-document-revisions' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
@@ -182,6 +221,49 @@ class WP_Document_Revisions_AI_Summary_REST {
 				'generated_at' => $stored['generated_at'],
 				'reviewed_by'  => $stored['reviewed_by'],
 				'reviewed_at'  => $stored['reviewed_at'],
+			),
+			200
+		);
+	}
+
+	/**
+	 * GET handler — return the unified diff between the revision and the
+	 * one that precedes it within the same document.
+	 *
+	 * Response shape (always includes `status`):
+	 *
+	 *   { "status": "no_prior", "diff": "", "prior_revision": 0 }
+	 *   { "status": "identical"|"too_large"|"old_text_missing"|"new_text_missing",
+	 *     "diff": "", "prior_revision": 123 }
+	 *   { "status": "ok", "diff": "@@ ...", "prior_revision": 123 }
+	 *
+	 * @param WP_REST_Request $request incoming request.
+	 * @return WP_REST_Response
+	 */
+	public static function get_diff( WP_REST_Request $request ): WP_REST_Response {
+		$ids = self::resolve_ids( $request );
+		// resolve_ids() already validated for the permission callback.
+
+		$prior_id = WP_Document_Revisions_AI_Summary::prior_revision_id( $ids['rev_id'], $ids['doc_id'] );
+		if ( 0 === $prior_id ) {
+			// Initial upload — nothing precedes it to diff against.
+			return new WP_REST_Response(
+				array(
+					'status'         => 'no_prior',
+					'diff'           => '',
+					'prior_revision' => 0,
+				),
+				200
+			);
+		}
+
+		$result = WP_Document_Revisions_Text_Diff::diff_revisions( $prior_id, $ids['rev_id'] );
+
+		return new WP_REST_Response(
+			array(
+				'status'         => $result['status'],
+				'diff'           => $result['diff'],
+				'prior_revision' => $prior_id,
 			),
 			200
 		);

--- a/tests/class-test-wp-document-revisions-ai-summary-rest.php
+++ b/tests/class-test-wp-document-revisions-ai-summary-rest.php
@@ -238,4 +238,65 @@ class Test_WP_Document_Revisions_AI_Summary_REST extends Test_Common_WPDR {
 
 		self::assertSame( 404, $response->get_status() );
 	}
+
+	/**
+	 * Build a relative REST route for the diff endpoint.
+	 *
+	 * @param int $doc_id document post ID.
+	 * @param int $rev_id revision attachment ID.
+	 * @return string the full route path.
+	 */
+	private function diff_route( int $doc_id, int $rev_id ): string {
+		return sprintf( '/wpdr/v1/documents/%d/revisions/%d/diff', $doc_id, $rev_id );
+	}
+
+	/**
+	 * GET diff reports `no_prior` for a document's first (initial) revision,
+	 * since there is nothing preceding it to diff against. (#531)
+	 */
+	public function test_diff_returns_no_prior_for_initial_revision() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		list( $doc_id, $attach_id ) = $this->create_document_with_attachment();
+
+		$response = $this->server->dispatch(
+			new WP_REST_Request( 'GET', $this->diff_route( $doc_id, $attach_id ) )
+		);
+
+		self::assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		self::assertSame( 'no_prior', $data['status'] );
+		self::assertSame( '', $data['diff'] );
+		self::assertSame( 0, $data['prior_revision'] );
+	}
+
+	/**
+	 * GET diff returns 404 when the revision does not belong to the claimed
+	 * document — same probe-resistance as the summary routes. (#531)
+	 */
+	public function test_diff_returns_404_when_revision_does_not_match_document() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		list( $doc_a, )  = $this->create_document_with_attachment();
+		list( , $rev_b ) = $this->create_document_with_attachment();
+
+		$response = $this->server->dispatch(
+			new WP_REST_Request( 'GET', $this->diff_route( $doc_a, $rev_b ) )
+		);
+
+		self::assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * GET diff is rejected for a user who can read the document but lacks
+	 * the `read_document_revisions` capability (e.g. a subscriber). (#531)
+	 */
+	public function test_diff_requires_read_document_revisions_capability() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		list( $doc_id, $attach_id ) = $this->create_document_with_attachment();
+
+		$response = $this->server->dispatch(
+			new WP_REST_Request( 'GET', $this->diff_route( $doc_id, $attach_id ) )
+		);
+
+		self::assertContains( $response->get_status(), array( 401, 403 ) );
+	}
 }


### PR DESCRIPTION
## Summary

Implements one of the two actionable items in #531 — the deferred third read path from the #514 phase-11 design:

```
GET /wpdr/v1/documents/<doc_id>/revisions/<rev_id>/diff
```

Returns the unified diff between the revision attachment and the one immediately preceding it within the same document — the same change signal that produces the AI summary — by reusing the existing `WP_Document_Revisions_AI_Summary::prior_revision_id()` and `WP_Document_Revisions_Text_Diff::diff_revisions()`.

**Capability:** `read_document` on the document **and** `read_document_revisions` (revisions are more sensitive than the current file, so this matches the revision-listing gate — exactly the mapping called out in #531/#514).

**Response envelope** mirrors the diff utility's status vocabulary, plus a `no_prior` status for a document's initial revision:
```json
{ "status": "ok"|"identical"|"too_large"|"old_text_missing"|"new_text_missing"|"no_prior",
  "diff": "@@ ...", "prior_revision": 123 }
```

Use case (from #531): let an editor view the diff that produced a summary before marking it reviewed.

## Tests
Adds endpoint tests for the no-prior path, 404 probe-resistance (revision not in document), and the `read_document_revisions` capability gate. Diff *content* is already covered by the text-diff unit tests, so these cover the wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)