### PR TITLE
Finalize 5.1.0 changelog and rebuild readme.txt

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,11 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 * Fix to ensure that only one document file can be loaded at a time. (#539)
 * Refactor to include class variables in trait files if only used there. (#547)
 * Remove type definition from the_title filter causing PHP crash due to invalid parameter being passed. (#550)
+* Migrate the legacy 'document_attachment_id' post meta to the protected '_document_attachment_id' key on access. (#547)
+* Provide a 'wpdr/v1/documents/.../revisions/.../diff' REST endpoint returning the per-revision text diff that drives the AI summary, gated on read_document_revisions. (#531)
+* Add a "Mark reviewed" action to the AI revision-summary suggestion banner so an editor can record that a summary has been human-reviewed. (#531)
+* Resolve the uploaded document file URL from the upload request rather than the global post object. (#569)
+* Fix duplicate upload handling so reopening the media frame no longer fires the upload callback more than once. (#568)
 
 ### 5.0.0
 

--- a/readme.txt
+++ b/readme.txt
@@ -234,6 +234,11 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 * Fix to ensure that only one document file can be loaded at a time. (#539)
 * Refactor to include class variables in trait files if only used there. (#547)
 * Remove type definition from the_title filter causing PHP crash due to invalid parameter being passed. (#550)
+* Migrate the legacy 'document_attachment_id' post meta to the protected '_document_attachment_id' key on access. (#547)
+* Provide a 'wpdr/v1/documents/.../revisions/.../diff' REST endpoint returning the per-revision text diff that drives the AI summary, gated on read_document_revisions. (#531)
+* Add a "Mark reviewed" action to the AI revision-summary suggestion banner so an editor can record that a summary has been human-reviewed. (#531)
+* Resolve the uploaded document file URL from the upload request rather than the global post object. (#569)
+* Fix duplicate upload handling so reopening the media frame no longer fires the upload callback more than once. (#568)
 
 = 5.0.0 =
 


### PR DESCRIPTION
## Summary

Prepares the (still-untagged) **5.1.0** release. Since 5.1.0 hasn't been cut yet — there's no `5.1.0` git tag and `deploy.yml` only fires on a tag push — the changes merged after the initial 5.1.0 changelog (#566) fold into the same release:

- per-revision **diff REST endpoint** (#531 / #575)
- **"Mark reviewed"** AI-summary action (#531 / #576)
- upload-URL resolved from the request (#569 / #574)
- **duplicate-upload** fix on media-frame reopen (#568)
- legacy `document_attachment_id` → `_document_attachment_id` **meta migration** (#547)

Adds those bullets to `docs/changelog.md` and regenerates `readme.txt` via `script/build-readme` so the wordpress.org readme (stable tag 5.1.0 + changelog) is in sync. Version refs (`Version:`, `WPDR_VERSION`, `@version`, `Stable tag`, `docs/header.md`) are already consistent at 5.1.0.

## Remaining release steps (manual / not in this PR)
1. Merge this.
2. Push the **`5.1.0` git tag** → `deploy.yml` deploys to WordPress.org.
3. The POT automation (`pot.yml`) picks up the new translatable strings ("Mark reviewed", etc.) on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)