### PR TITLE
Fix assets-only deploy (IGNORE_OTHER_FILES)

### DIFF
--- a/.github/workflows/deploy-assets.yml
+++ b/.github/workflows/deploy-assets.yml
@@ -28,5 +28,9 @@ jobs:
               uses: 10up/action-wordpress-plugin-asset-update@stable
               env:
                   SLUG: wp-document-revisions
+                  # We don't commit build artifacts (vendor/, build/) to git, so the
+                  # default "verify only readme/assets changed" check sees them as
+                  # deletions and fails. This scopes the action to readme + assets only.
+                  IGNORE_OTHER_FILES: true
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
Follow-up to #580. The new `deploy-assets.yml` workflow failed on its first run:

```
➤ Preparing files...
ℹ︎ Reverting changes in vendor/composer directory
svn: E000002: Can't create directory '.../trunk/vendor/composer': No such file or directory
##[error]Process completed with exit code 1.
```

**Cause:** `10up/action-wordpress-plugin-asset-update` defaults to copying the whole plugin tree (respecting `.distignore`) to confirm that *only* readme/asset files changed since the last deploy. This repo doesn't commit build artifacts (`vendor/`, `build/`), and — unlike the release workflow — this assets job doesn't run `composer install`/`npm run build`, so those dirs are absent and read as deletions, aborting the run **before any SVN commit** (live assets were untouched).

**Fix:** set `IGNORE_OTHER_FILES: true`, the documented switch for updating assets/readme from a repo that doesn't commit built files.

After merge I'll trigger it via `workflow_dispatch` to publish the icon + banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)