### PR TITLE
Fix Workflow State / Owner meta box select overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -39,6 +39,12 @@
 	margin-top: -2px;
 }
 
+/* Contain the right-floated select so it doesn't spill below the meta box. */
+#workflow-state .inside,
+#authordiv .inside {
+	overflow: hidden;
+}
+
 #lock_override {
 	float: right;
 	text-align: right;


### PR DESCRIPTION
## Problem

On the document edit screen, the **Current State** (Workflow State) and **Document Owner** (Owner) `<select>` dropdowns spill a few pixels **below their meta box border**:

`css/style.css`
```css
#workflow-state select,
#authordiv select {
	float: right;
	margin-top: -2px;
}
```

The selects are floated right, but the meta box `.inside` containers are `overflow: visible`, so they don't contain the float. When the select is taller than its label line, it overflows the box.

## Fix

Give the two `.inside` containers their own block formatting context so they contain the floated select:

```css
#workflow-state .inside,
#authordiv .inside {
	overflow: hidden;
}
```

## Verification

Measured in a live WordPress 7.0 admin (via Playground), document edit screen:

| Meta box | select bottom − container bottom (before) | after |
|---|---|---|
| Workflow State | **+6px** (overflowing) | **−12px** (contained) |
| Owner | **+8px** (overflowing) | **−12px** (contained) |

The container grows to wrap the select; the native dropdown popup is unaffected (browser overlay, not clipped by `overflow: hidden`).

> Changelog entry intentionally omitted — 5.1.0 was just finalized and there's no unreleased section yet; happy to slot it into whichever version you're targeting next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)