### PR TITLE
Recover document's own attachment instead of dropping it on a rejected marker

### DIFF
--- a/includes/trait-wp-document-revisions-admin-editor.php
+++ b/includes/trait-wp-document-revisions-admin-editor.php
@@ -359,9 +359,10 @@ trait WP_Document_Revisions_Admin_Editor {
 		if ( isset( $_GET['action'] ) && 'restore' === $_GET['action'] ) {
 			$attach_id = absint( $wpdr->extract_document_id( $postarr['post_content'] ) );
 			// The attachment id comes from (forgeable) post_content here, so if one is present
-			// confirm it actually belongs to this document before trusting it.
+			// confirm it actually belongs to this document. If it does not, don't trust it, but
+			// don't drop the document's real attachment either — recover the authoritative one.
 			if ( $attach_id > 0 && ! $this->attachment_belongs_to_document( $attach_id, $doc_id ) ) {
-				return $data;
+				$attach_id = $this->authoritative_attachment_id( $doc_id );
 			}
 			update_post_meta( $doc_id, '_document_attachment_id', $attach_id );
 		} else {
@@ -386,11 +387,14 @@ trait WP_Document_Revisions_Admin_Editor {
 			$raw_posted = wp_unslash( $_POST['post_content'] );
 			$attach_id  = absint( $wpdr->extract_document_id( $raw_posted ) );
 
-			// The id is taken from forgeable POST data, so confirm the attachment actually
-			// belongs to this document before storing it as the document's marker. Without this
-			// an editor could point their document at another document's attachment (IDOR).
+			// The id is forgeable POST data. Rather than trust a foreign attachment (IDOR) or
+			// drop the document's real attachment by saving the kses-stripped content, recover
+			// the authoritative attachment that is actually parented to this document.
 			if ( ! $this->attachment_belongs_to_document( $attach_id, $doc_id ) ) {
-				return $data;
+				$attach_id = $this->authoritative_attachment_id( $doc_id );
+				if ( ! $attach_id ) {
+					return $data;
+				}
 			}
 		}
 
@@ -429,6 +433,30 @@ trait WP_Document_Revisions_Admin_Editor {
 		return ( $attachment instanceof WP_Post
 			&& 'attachment' === $attachment->post_type
 			&& (int) $attachment->post_parent === $doc_id );
+	}
+
+
+	/**
+	 * Returns the attachment id that legitimately belongs to a document, or 0 if none.
+	 *
+	 * Used to recover the correct attachment when an extracted or forged id fails the
+	 * ownership check, so a save can never drop the document's real attachment reference
+	 * (nor substitute another document's attachment). Scoped to attachments parented to
+	 * the document, so the result is owned by construction. This is the same authoritative
+	 * source that save_document() falls back to.
+	 *
+	 * @since 5.1.2
+	 * @param int $doc_id the id of the document being saved.
+	 * @return int the id of the document's most recent attachment, or 0 if it has none.
+	 */
+	private function authoritative_attachment_id( int $doc_id ): int {
+		if ( $doc_id <= 0 ) {
+			return 0;
+		}
+
+		$latest = $this->get_latest_attachment( $doc_id );
+
+		return ( $latest instanceof WP_Post ? (int) $latest->ID : 0 );
 	}
 
 

--- a/tests/class-test-wp-document-revisions-admin-other.php
+++ b/tests/class-test-wp-document-revisions-admin-other.php
@@ -1099,6 +1099,60 @@ class Test_WP_Document_Revisions_Admin_Other extends Test_Common_WPDR {
 	}
 
 	/**
+	 * When a forged marker is rejected, a document that owns a real attachment must keep
+	 * that attachment rather than be saved with no attachment reference at all (the marker
+	 * is stripped before reaching the client, so an early return would drop it).
+	 */
+	public function test_restore_document_attachment_id_recovers_real_attachment_on_forged_marker() {
+		global $wpdr;
+
+		// Ensure we exercise the $_POST (normal save) branch, not the restore branch.
+		unset( $_GET['action'] );
+
+		// A real attachment belonging to a *different* document (the forgery target).
+		$victim_attach_id = (int) $wpdr->extract_document_id( get_post_field( 'post_content', self::$editor_public_post_2 ) );
+		self::assertGreaterThan( 0, $victim_attach_id, 'Victim attachment not found' );
+
+		// Attacker-owned document that DOES own an attachment, but with the meta not yet
+		// stored (legacy / unmigrated state), so the forgeable $_POST branch runs.
+		$doc = self::factory()->post->create(
+			array(
+				'post_title'   => 'Recover doc - ' . time(),
+				'post_status'  => 'publish',
+				'post_author'  => self::$editor_user_id,
+				'post_type'    => 'document',
+				'post_content' => '',
+			)
+		);
+		$own_attach_id = self::factory()->attachment->create(
+			array(
+				'post_parent' => $doc,
+				'post_status' => 'inherit',
+			)
+		);
+		delete_post_meta( $doc, '_document_attachment_id' );
+
+		$_POST['post_content'] = $wpdr->format_doc_id( $victim_attach_id );
+
+		$data    = array(
+			'post_type'    => 'document',
+			'post_content' => '',
+		);
+		$postarr = array(
+			'ID'           => $doc,
+			'post_content' => '',
+		);
+
+		$result   = $wpdr->admin->restore_document_attachment_id( $data, $postarr );
+		$resolved = (int) $wpdr->extract_document_id( $result['post_content'] );
+
+		unset( $_POST['post_content'] );
+
+		self::assertNotEquals( $victim_attach_id, $resolved, 'Forged foreign attachment must not be used' );
+		self::assertEquals( $own_attach_id, $resolved, "Document's own attachment must be recovered, not dropped" );
+	}
+
+	/**
 	 * Test revision summary.
 	 */
 	public function test_revision_summary_cb() {

--- a/tests/class-test-wp-document-revisions-admin-other.php
+++ b/tests/class-test-wp-document-revisions-admin-other.php
@@ -1115,7 +1115,7 @@ class Test_WP_Document_Revisions_Admin_Other extends Test_Common_WPDR {
 
 		// Attacker-owned document that DOES own an attachment, but with the meta not yet
 		// stored (legacy / unmigrated state), so the forgeable $_POST branch runs.
-		$doc = self::factory()->post->create(
+		$doc           = self::factory()->post->create(
 			array(
 				'post_title'   => 'Recover doc - ' . time(),
 				'post_status'  => 'publish',


### PR DESCRIPTION
## Summary

Follow-up to #584, addressing review feedback from @NeilWJames.

When the ownership check added in #584 rejects a forged or foreign attachment id, `restore_document_attachment_id()` previously returned the kses-stripped `post_content` **without** re-adding the marker. Because the WPDR marker is stripped before the content reaches the editor (`remove_attachment_id` on `content_edit_pre`), that early return could leave a document saved with **no attachment reference at all** — i.e. dropping a legitimate attachment, not just blocking the forged one.

This was mitigated in practice — `save_document()` (on `save_post_document`, which runs *after* `wp_insert_post_data`) recovers the correct attachment via `get_latest_attachment()` — but relying on a second hook to undo a drop is fragile, and Neil rightly flagged it.

## Change

Recover the authoritative attachment **in-place**: when the candidate id isn't parented to the document, fall back to a new `authoritative_attachment_id()` helper — the same `get_latest_attachment()` source `save_document()` uses — and only return early when the document genuinely has no attachment to recover.

Applied to **both** untrusted branches (the `$_POST` fallback and the revision-restore branch), so a forged save now both rejects the foreign id **and** preserves the document's real attachment. This also improves the legacy normal-save case (empty meta + marker stripped by kses), which previously leaned on `save_document` to heal.

## Notes on the rest of Neil's feedback

- **Nonce on restore:** intentionally not added — the restore action is already gated by core's `check_admin_referer( "restore-post_{$id}" )` in `wp-admin/revision.php`, so an extra nonce would be redundant.
- **Exploitability:** the `$_POST` (normal-save) branch is genuinely reachable — `$_POST['post_content']` is a submitted form field (the code already reads it raw as a kses fallback) — so the original #584 ownership check stands. The restore branch is the hard-to-forge one.

## Tests

Adds a regression test: a forged marker on a document that owns an attachment results in the document keeping **its own** attachment, rather than being dropped or pointed at the foreign one.

> Targets a 5.1.2 patch. No version bump here — that's handled separately at release-prep time (as #585 did for 5.1.1). Tests verified by reading (no local PHP); CI will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)