### PR TITLE
Update docs README header to the WP.org banner

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-![WP Document Revisions header logo](https://user-images.githubusercontent.com/282759/120903696-a46aaf00-c615-11eb-947e-60554e9fff95.png)
+![WP Document Revisions](https://ps.w.org/wp-document-revisions/assets/banner-1544x500.png)
 
 # WP Document Revisions
 


### PR DESCRIPTION
Replaces the legacy GitHub user-images header logo at the top of `docs/README.md` with the current WordPress.org plugin banner (`https://ps.w.org/wp-document-revisions/assets/banner-1544x500.png`), so the docs site header matches the refreshed WP.org directory branding shipped in #580/#581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)