### PR TITLE
Speed up CI: parallelize heavy jobs, cancel stale runs, npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,16 @@ on:
     pull_request:
         branches: [main]
 
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR) so
+# runners are freed for the latest commit instead of finishing stale runs.
+concurrency:
+    group: ci-${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
-    # Stage 1: Fast checks — lint, audit, and JS tests run first
+    # Lint, audit, and static analysis. All jobs below run in parallel from
+    # the start (no cross-job gating) so the slowest job — E2E — is the only
+    # thing on the critical path rather than lint + E2E in series.
     code-quality:
         runs-on: ubuntu-latest
         permissions:
@@ -104,7 +112,7 @@ jobs:
                       ${{ runner.os }}-node-22-
 
             - name: Install dependencies
-              run: npm install
+              run: npm ci
 
             - name: Audit dependencies
               run: npm audit --omit=dev
@@ -119,9 +127,8 @@ jobs:
                   flags: javascript
                   name: javascript-coverage
 
-    # Stage 2: PHPUnit tests — only run after Stage 1 passes
+    # PHPUnit tests (PR matrix).
     phpunit:
-        needs: [code-quality, jest]
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -196,7 +203,6 @@ jobs:
 
     # Extended PHPUnit matrix — push to main only
     phpunit-extended:
-        needs: [code-quality, jest]
         if: github.event_name == 'push'
         runs-on: ubuntu-latest
         permissions:
@@ -274,7 +280,6 @@ jobs:
 
     # E2E tests — Playwright against a real WordPress instance
     e2e:
-        needs: [code-quality, jest]
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -297,7 +302,7 @@ jobs:
                       ${{ runner.os }}-node-22-
 
             - name: Install dependencies
-              run: npm install
+              run: npm ci
 
             - name: Build blocks
               run: npm run build:blocks && npm run build:editor


### PR DESCRIPTION
Follow-up to #607. Cuts CI wall-clock and runner waste without dropping any coverage.

Measured from recent green runs, the critical path was **Stage 1 (~55s lint/JS) → E2E (~3m)** in series ≈ **4m**. Every PHPUnit job is <90s and already parallel, so they were never what you waited on.

## Changes

1. **Ungate the heavy jobs.** Removed `needs: [code-quality, jest]` from `phpunit`, `phpunit-extended`, and `e2e` so they start immediately in parallel. Critical path drops to just E2E (~3m) — roughly **25% faster** on green runs.
2. **Concurrency cancellation.** Added a `concurrency` group with `cancel-in-progress: true`, so rapid pushes to a PR cancel superseded runs instead of letting stale ~4m runs finish and hog runners.
3. **`npm install` → `npm ci`** in `jest` and `e2e` — faster and deterministic now that `package-lock.json` is authoritative.

## Trade-off

Ungating means the heavy jobs no longer skip when lint fails, costing some runner minutes on broken pushes in exchange for faster feedback on green ones. `cancel-in-progress` offsets much of that during iteration.

## Considered but excluded

- **Dropping `imagick`** from the PHPUnit `extensions:` list: the list includes no GD fallback, so WordPress would have no image editor and image/thumbnail tests could break. It also only touches the ~60s PHPUnit jobs, not the E2E long pole — a false economy.
- **Docker-layer caching for `wp-env`** in E2E: fragile and low return; E2E's cost is mostly image pulls.

Validated with `actionlint` (only a pre-existing shellcheck info remains, unrelated to this diff).