### PR TITLE
Disable unused wp-env tests environment

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,6 @@
 {
 	"core": null,
+	"testsEnvironment": false,
 	"plugins": [
 		"."
 	],


### PR DESCRIPTION
Small follow-up to #609 (its `testsEnvironment: false` commit landed after the merge, so it was orphaned — re-applying it here).

`wp-env` boots both a development and a tests environment by default, which is now deprecated (warns on every E2E run). The E2E suite only ever hits the **development** environment (port 8888) — `playwright.config.mjs` and `tests/e2e/config/global-setup.js` both pin the base URL to `localhost:8888`, and nothing references the tests port 8889.

Setting `"testsEnvironment": false` in `.wp-env.json`:
- Skips booting the second environment → shaves time off `wp-env start` in the E2E job.
- Clears the deprecation warning.

No test behavior changes (the tests environment was never used).