### PR TITLE
PHPStan behavioral tier: 39 → 6 baselined errors + 2 real bugs (#612)

### DIFF
--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -104,7 +104,7 @@ class WP_Document_Revisions_Admin {
 		add_filter( 'manage_document_posts_columns', array( $this, 'add_currently_editing_column' ), 20 );
 		add_action( 'manage_document_posts_custom_column', array( $this, 'currently_editing_column_cb' ), 10, 2 );
 		add_action( 'restrict_manage_posts', array( $this, 'filter_documents_list' ) );
-		add_filter( 'parse_query', array( $this, 'convert_workflow_state_to_post_status' ) );
+		add_action( 'parse_query', array( $this, 'convert_workflow_state_to_post_status' ) );
 		add_filter( 'wp_dropdown_users_args', array( $this, 'filter_user_dropdown' ), 10, 2 );
 
 		// settings.

--- a/includes/class-wp-document-revisions-front-end.php
+++ b/includes/class-wp-document-revisions-front-end.php
@@ -183,7 +183,7 @@ class WP_Document_Revisions_Front_End {
 			<li class="revision revision-<?php echo esc_attr( $revision->ID ); ?>" >
 				<?php
 				// html - string not to be translated.
-				printf( '<a href="%1$s" title="%2$s" id="%3$s" class="timestamp"', esc_url( get_permalink( $revision->ID ) ), esc_attr( $revision->post_modified ), esc_html( strtotime( $revision->post_modified ) ) );
+				printf( '<a href="%1$s" title="%2$s" id="%3$s" class="timestamp"', esc_url( get_permalink( $revision->ID ) ), esc_attr( $revision->post_modified ), esc_html( (string) strtotime( $revision->post_modified ) ) );
 				echo ( $atts_new_tab ? ' target="_blank"' : '' );
 				printf( '>%s</a> <span class="agoby">', esc_html( human_time_diff( strtotime( $revision->post_modified_gmt ), time() ) ) . wp_kses_post( $atts_show_pdf ) );
 				esc_html_e( 'ago by', 'wp-document-revisions' );

--- a/includes/class-wp-document-revisions-front-end.php
+++ b/includes/class-wp-document-revisions-front-end.php
@@ -514,7 +514,7 @@ class WP_Document_Revisions_Front_End {
 		$wpdr = self::$parent;
 
 		// enqueue CSS for shortcode.
-		wp_enqueue_style( 'wp-document-revisions-front', plugins_url( '/css/style-front.css', __DIR__ ), null, $wpdr->version );
+		wp_enqueue_style( 'wp-document-revisions-front', plugins_url( '/css/style-front.css', __DIR__ ), array(), $wpdr->version );
 	}
 
 

--- a/includes/class-wp-document-revisions-recently-revised-widget.php
+++ b/includes/class-wp-document-revisions-recently-revised-widget.php
@@ -48,7 +48,7 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	 * Generate widget contents.
 	 *
 	 * @param mixed[] $args the widget arguments.
-	 * @param Object  $instance the WP Document Revisions instance.
+	 * @param array   $instance the WP Document Revisions instance.
 	 */
 	public function widget_gen( array $args, $instance ) {
 		global $wpdr;
@@ -171,8 +171,8 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	/**
 	 * Callback to display widget contents in classic widget.
 	 *
-	 * @param Array  $args the widget arguments.
-	 * @param Object $instance the WP Document Revisions instance.
+	 * @param array $args the widget arguments.
+	 * @param array $instance the WP Document Revisions instance.
 	 */
 	public function widget( $args, $instance ) {
 
@@ -185,7 +185,7 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	/**
 	 * Callback to display widget options form.
 	 *
-	 * @param Object $instance the WP Document Revisions instance.
+	 * @param array $instance the WP Document Revisions instance.
 	 */
 	public function form( $instance ) {
 
@@ -237,8 +237,8 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	/**
 	 * Sanitizes options and saves.
 	 *
-	 * @param Object $new_instance the new instance.
-	 * @param Object $old_instance the old instance.
+	 * @param array $new_instance the new instance.
+	 * @param array $old_instance the old instance.
 	 */
 	public function update( $new_instance, $old_instance ) {
 

--- a/includes/class-wp-document-revisions-validate-structure.php
+++ b/includes/class-wp-document-revisions-validate-structure.php
@@ -563,6 +563,7 @@ class WP_Document_Revisions_Validate_Structure {
 			/**
 			 * Filters whether to validate the document structure for a document.
 			 *
+			 * @param bool   $valid   Whether to validate the document (default true).
 			 * @param int    $doc_id  Document post ID.
 			 * @param string $content Document post content.
 			 */
@@ -874,7 +875,7 @@ class WP_Document_Revisions_Validate_Structure {
 				// post name without extension is OK.
 				if ( $guid !== $permalink && $guid !== $p2 ) {
 					// get the extension.
-					$file       = get_post_meta( $attach_id, '_wp_attached_file', true );
+					$file       = get_post_meta( (int) $attach_id, '_wp_attached_file', true );
 					$permalink .= self::$parent->get_extension( $file );
 					$p2         = $permalink . '/';
 					if ( $guid !== $permalink && $guid !== $p2 ) {

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -161,8 +161,8 @@ class WP_Document_Revisions {
 		add_filter( 'rewrite_rules_array', array( $this, 'revision_rewrite' ) );
 		add_filter( 'transient_rewrite_rules', array( $this, 'revision_rewrite' ) );
 		add_action( 'init', array( $this, 'inject_rules' ) );
-		add_action( 'post_type_link', array( $this, 'permalink' ), 10, 3 );
-		add_action( 'post_link', array( $this, 'permalink' ), 10, 3 );
+		add_filter( 'post_type_link', array( $this, 'permalink' ), 10, 3 );
+		add_filter( 'post_link', array( $this, 'permalink' ), 10, 3 );
 		add_filter( 'template_include', array( $this, 'serve_file' ), 10, 1 );
 		add_filter( 'serve_document_auth', array( $this, 'serve_document_auth' ), 10, 3 );
 		add_action( 'parse_request', array( $this, 'ie_cache_fix' ) );
@@ -186,7 +186,7 @@ class WP_Document_Revisions {
 		add_filter( 'attachment_link', array( $this, 'attachment_link_filter' ), 10, 2 );
 		add_filter( 'get_attached_file', array( $this, 'get_attached_file_filter' ), 10, 2 );
 		add_filter( 'wp_handle_upload_prefilter', array( $this, 'filename_rewrite' ) );
-		add_filter( 'wp_handle_upload', array( $this, 'rewrite_file_url' ), 10, 2 );
+		add_filter( 'wp_handle_upload', array( $this, 'rewrite_file_url' ), 10, 1 );
 		// Hide slug by changing metadata name - do early in case of WPML.
 		add_filter( 'wp_generate_attachment_metadata', array( $this, 'hide_doc_attach_slug' ), 5, 3 );
 		// initialise document directory (will itself populate cache).

--- a/includes/revision-feed.php
+++ b/includes/revision-feed.php
@@ -45,7 +45,7 @@ echo '<?xml version="1.0" encoding="' . ent2ncr( esc_attr( get_option( 'blog_cha
 	<atom:link href="<?php self_link(); ?>" rel="self" type="application/rss+xml" />
 	<link><?php bloginfo_rss( 'url' ); ?></link>
 	<description><?php bloginfo_rss( 'description' ); ?></description>
-	<lastBuildDate><?php echo ent2ncr( esc_html( mysql2date( 'D, d M Y H:i:s +0000', get_lastpostmodified( 'GMT' ), false ) ) ); ?></lastBuildDate>
+	<lastBuildDate><?php echo ent2ncr( esc_html( mysql2date( 'D, d M Y H:i:s +0000', get_lastpostmodified( 'gmt' ), false ) ) ); ?></lastBuildDate>
 	<language><?php echo ent2ncr( esc_html( get_option( 'rss_language' ) ) ); ?></language>
 	<sy:updatePeriod><?php echo ent2ncr( esc_html( apply_filters( 'rss_update_period', 'hourly' ) ) ); ?></sy:updatePeriod>
 	<sy:updateFrequency><?php echo ent2ncr( esc_html( apply_filters( 'rss_update_frequency', '1' ) ) ); ?></sy:updateFrequency>

--- a/includes/trait-wp-document-revisions-admin-editor.php
+++ b/includes/trait-wp-document-revisions-admin-editor.php
@@ -580,7 +580,7 @@ trait WP_Document_Revisions_Admin_Editor {
 			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery	
 			wp_cache_delete( self::$last_revn, 'posts' );
 			wp_cache_delete( $doc_id, 'posts' );
-			clean_post_cache( self::$last_revn_excerpt );
+			clean_post_cache( $doc_id );
 			clean_post_cache( self::$last_revn );
 		}
 
@@ -709,7 +709,7 @@ trait WP_Document_Revisions_Admin_Editor {
 		}
 
 		// enqueue CSS.
-		wp_enqueue_style( 'wp-document-revisions', plugins_url( '/css/style.css', __DIR__ ), null, $wpdr->version );
+		wp_enqueue_style( 'wp-document-revisions', plugins_url( '/css/style.css', __DIR__ ), array(), $wpdr->version );
 	}
 
 

--- a/includes/trait-wp-document-revisions-file-handler.php
+++ b/includes/trait-wp-document-revisions-file-handler.php
@@ -232,6 +232,10 @@ trait WP_Document_Revisions_File_Handler {
 		// Will we use gzip or deflate output? Do this early as can impact headers and these need outputting before any output.
 		// Does the user accept gzip or deflate?
 		$gzip_dflt = false;
+		// Default so $comp_type is always defined: the document_serve_use_gzip
+		// filter can force compression even when the client advertised no
+		// encoding (in which case the gzip/deflate branches below never run).
+		$comp_type = 'deflate';
 		if ( isset( $_SERVER['HTTP_ACCEPT_ENCODING'] ) ) {
 			// phpcs:ignore
 			$encoding = strtolower( $_SERVER['HTTP_ACCEPT_ENCODING'] );
@@ -256,7 +260,7 @@ trait WP_Document_Revisions_File_Handler {
 		 */
 		$compress = apply_filters( 'document_serve_use_gzip', $gzip_dflt, $mimetype, $filesize );
 
-		$headers['Content-Length'] = $filesize;
+		$headers['Content-Length'] = (string) $filesize;
 		if ( $compress ) {
 			// request compression. Remove Length as possibly wrong and HTTP/2 fails if length wrong.
 			// phpcs:ignore
@@ -415,7 +419,7 @@ trait WP_Document_Revisions_File_Handler {
 			$headers['Content-Encoding'] = ( 'gzip' === $comp_type ) ? 'gzip' : 'deflate';
 			if ( array_key_exists( 'Content-Length', $headers ) ) {
 				// only update to the correct value.
-				$headers['Content-Length'] = ob_get_length();
+				$headers['Content-Length'] = (string) ob_get_length();
 			}
 			// only know the length after writing to buffer, so only output headers now.
 			$this->serve_headers( $headers, $file );

--- a/includes/trait-wp-document-revisions-query.php
+++ b/includes/trait-wp-document-revisions-query.php
@@ -369,7 +369,7 @@ trait WP_Document_Revisions_Query {
 	 * Gets a file extension from a post.
 	 *
 	 * @since 0.5
-	 * @param object|int $document_or_attachment document or attachment.
+	 * @param object|int|string $document_or_attachment document or attachment.
 	 * @return string the extension to the latest revision
 	 */
 	public function get_file_type( $document_or_attachment = '' ): string {
@@ -502,14 +502,12 @@ trait WP_Document_Revisions_Query {
 	 */
 	public function posts_results( array $results, WP_Query $query_object ): array {
 		$match = false;
-		if ( is_array( $results ) ) {
-			foreach ( $results as $key => $result ) {
-				// confirm a document.
-				if ( $this->verify_post_type( $result ) ) {
-					// user has no access, remove from result.
-					unset( $results[ $key ] );
-					$match = true;
-				}
+		foreach ( $results as $key => $result ) {
+			// confirm a document.
+			if ( $this->verify_post_type( $result ) ) {
+				// user has no access, remove from result.
+				unset( $results[ $key ] );
+				$match = true;
 			}
 		}
 		// re-evaluate count.
@@ -517,17 +515,9 @@ trait WP_Document_Revisions_Query {
 			// reindex array.
 			$results = array_values( $results );
 
-			if ( is_array( $results ) ) {
-				$query_object->post_count  = count( $results );
-				$query_object->found_posts = $query_object->post_count;
-				$query_object->is_404      = (bool) ( 0 === $query_object->post_count );
-			} elseif ( null === $results ) {
-				$query_object->post_count  = 0;
-				$query_object->found_posts = 0;
-				$query_object->is_404      = true;
-			} else {
-				$query_object->found_posts = 1;
-			}
+			$query_object->post_count  = count( $results );
+			$query_object->found_posts = $query_object->post_count;
+			$query_object->is_404      = (bool) ( 0 === $query_object->post_count );
 		}
 
 		return $results;

--- a/includes/trait-wp-document-revisions-revisions.php
+++ b/includes/trait-wp-document-revisions-revisions.php
@@ -38,7 +38,7 @@ trait WP_Document_Revisions_Revisions {
 		$document = get_post( $post_id );
 
 		if ( ! $document || 'document' !== $document->post_type ) {
-			return false;
+			return array();
 		}
 
 		$cache = wp_cache_get( $post_id, 'document_revisions' );
@@ -164,7 +164,7 @@ trait WP_Document_Revisions_Revisions {
 	 *
 	 * @since 0.5
 	 * @param int $revision_id the revision ID.
-	 * @return int revision number
+	 * @return int|false revision number, or false if the revision has no parent.
 	 */
 	public function get_revision_number( int $revision_id ) {
 		$revision = get_post( $revision_id );

--- a/includes/trait-wp-document-revisions-revisions.php
+++ b/includes/trait-wp-document-revisions-revisions.php
@@ -51,7 +51,7 @@ trait WP_Document_Revisions_Revisions {
 			$document->post_modified_gmt = current_time( 'mysql', true );
 		}
 		// correct the modified date.
-		$document->post_date = gmdate( 'Y-m-d H:i:s', (int) get_post_modified_time( 'U', null, $post_id ) );
+		$document->post_date = gmdate( 'Y-m-d H:i:s', (int) get_post_modified_time( 'U', false, $post_id ) );
 
 		// fix for Quotes in the most recent post because it comes from get_post.
 		$document->post_excerpt = html_entity_decode( $document->post_excerpt );
@@ -188,7 +188,7 @@ trait WP_Document_Revisions_Revisions {
 	public function override_lock( bool $send_notice = true ): void {
 		check_ajax_referer( 'wp-document-revisions', 'nonce' );
 
-		$post_id = ( isset( $_POST['post_id'] ) ? sanitize_text_field( wp_unslash( $_POST['post_id'] ) ) : false );
+		$post_id = ( isset( $_POST['post_id'] ) ? (int) sanitize_text_field( wp_unslash( $_POST['post_id'] ) ) : false );
 
 		// verify current user can edit
 		// consider a specific permission check here.
@@ -314,8 +314,8 @@ trait WP_Document_Revisions_Revisions {
 		/**
 		 * Filters the user locking the document file.
 		 *
-		 * @param string  $user     user locking the document.
-		 * @param WP_Post $document Post object.
+		 * @param int|false $user     user ID locking the document, or false if none.
+		 * @param WP_Post   $document Post object.
 		 */
 		$user = apply_filters( 'document_lock_check', $user, $document );
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,48 +25,6 @@ parameters:
 			path: includes/class-wp-document-revisions-front-end.php
 
 		-
-			message: '#^Method WP_Document_Revisions_Recently_Revised_Widget\:\:update\(\) should return array but returns ArrayAccess\.$#'
-			identifier: return.type
-			count: 1
-			path: includes/class-wp-document-revisions-recently-revised-widget.php
-
-		-
-			message: '#^Parameter \#1 \$instance \(object\) of method WP_Document_Revisions_Recently_Revised_Widget\:\:form\(\) should be compatible with parameter \$instance \(array\<string, mixed\>\) of method WP_Widget\<array\<string, mixed\>\>\:\:form\(\)$#'
-			identifier: method.childParameterType
-			count: 1
-			path: includes/class-wp-document-revisions-recently-revised-widget.php
-
-		-
-			message: '#^Parameter \#1 \$new_instance \(object\) of method WP_Document_Revisions_Recently_Revised_Widget\:\:update\(\) should be compatible with parameter \$new_instance \(array\<string, mixed\>\) of method WP_Widget\<array\<string, mixed\>\>\:\:update\(\)$#'
-			identifier: method.childParameterType
-			count: 1
-			path: includes/class-wp-document-revisions-recently-revised-widget.php
-
-		-
-			message: '#^Parameter \#2 \$instance \(object\) of method WP_Document_Revisions_Recently_Revised_Widget\:\:widget\(\) should be compatible with parameter \$instance \(array\<string, mixed\>\) of method WP_Widget\<array\<string, mixed\>\>\:\:widget\(\)$#'
-			identifier: method.childParameterType
-			count: 1
-			path: includes/class-wp-document-revisions-recently-revised-widget.php
-
-		-
-			message: '#^Parameter \#2 \$instance of method WP_Document_Revisions_Recently_Revised_Widget\:\:widget_gen\(\) expects object, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions-recently-revised-widget.php
-
-		-
-			message: '#^Parameter \#2 \$instance of method WP_Document_Revisions_Recently_Revised_Widget\:\:widget_gen\(\) expects object, array\<string, mixed\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions-recently-revised-widget.php
-
-		-
-			message: '#^Parameter \#2 \$old_instance \(object\) of method WP_Document_Revisions_Recently_Revised_Widget\:\:update\(\) should be compatible with parameter \$old_instance \(array\<string, mixed\>\) of method WP_Widget\<array\<string, mixed\>\>\:\:update\(\)$#'
-			identifier: method.childParameterType
-			count: 1
-			path: includes/class-wp-document-revisions-recently-revised-widget.php
-
-		-
 			message: '#^Expected 3 @param tags, found 2\.$#'
 			identifier: paramTag.count
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Filter callback return statement is missing\.$#'
-			identifier: return.missing
-			count: 1
-			path: includes/class-wp-document-revisions-admin.php
-
-		-
 			message: '#^Parameter \#1 \$args of function wp_dropdown_users expects array\{show_option_all\?\: string, show_option_none\?\: string, option_none_value\?\: int\|string, hide_if_only_one_author\?\: string, orderby\?\: array\|string, order\?\: string, include\?\: array\<int\>\|string, exclude\?\: array\<int\>\|string, \.\.\.\}, array\{name\: ''author'', show_option_all\: string, value_field\: ''slug'', selected\: string\|false\|null, orderby\: ''name'', order\: ''ASC'', wpdr_added\: ''list'', has_published_posts\: array\{''document''\}\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -19,86 +13,8 @@ parameters:
 			path: includes/class-wp-document-revisions-front-end.php
 
 		-
-			message: '#^Parameter \#1 \$text of function esc_html expects string, \(int\|false\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions-front-end.php
-
-		-
-			message: '#^Expected 3 @param tags, found 2\.$#'
-			identifier: paramTag.count
-			count: 1
-			path: includes/class-wp-document-revisions-validate-structure.php
-
-		-
-			message: '#^Parameter \#1 \$post_id of function get_post_meta expects int, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions-validate-structure.php
-
-		-
-			message: '#^Action callback returns string but should not return anything\.$#'
-			identifier: return.void
-			count: 2
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Call to function is_array\(\) with list\<mixed\> will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Callback expects 1 parameter, \$accepted_args is set to 2\.$#'
-			identifier: arguments.count
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Default value of the parameter \#1 \$document_or_attachment \(string\) of method WP_Document_Revisions\:\:get_file_type\(\) is incompatible with type int\|object\.$#'
-			identifier: parameter.defaultValue
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
 			message: '#^Left side of && is always true\.$#'
 			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Method WP_Document_Revisions\:\:get_revision_number\(\) should return int but returns false\.$#'
-			identifier: return.type
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Method WP_Document_Revisions\:\:get_revisions\(\) should return array but returns false\.$#'
-			identifier: return.type
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Parameter \#1 \$headers of method WP_Document_Revisions\:\:serve_headers\(\) expects array\<string\>, array\<string, int\<0, max\>\|string\|false\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Parameter \#1 \$headers of method WP_Document_Revisions\:\:serve_headers\(\) expects array\<string\>, array\<string, int\|string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between null and \*NEVER\* will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
 			count: 1
 			path: includes/class-wp-document-revisions.php
 
@@ -106,10 +22,4 @@ parameters:
 			message: '#^Unreachable statement \- code above always terminates\.$#'
 			identifier: deadCode.unreachable
 			count: 3
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Variable \$comp_type might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
 			path: includes/class-wp-document-revisions.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,18 +13,6 @@ parameters:
 			path: includes/class-wp-document-revisions-admin.php
 
 		-
-			message: '#^Parameter \#1 \$post of function clean_post_cache expects int\|WP_Post, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions-admin.php
-
-		-
-			message: '#^Parameter \#3 \$deps of function wp_enqueue_style expects array\<string\>, null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions-admin.php
-
-		-
 			message: '#^Parameter \#1 \$term of function get_term expects int\|object, string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -32,12 +20,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$text of function esc_html expects string, \(int\|false\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions-front-end.php
-
-		-
-			message: '#^Parameter \#3 \$deps of function wp_enqueue_style expects array\<string\>, null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: includes/class-wp-document-revisions-front-end.php
@@ -95,12 +77,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: includes/class-wp-document-revisions-validate-structure.php
-
-		-
-			message: '#^@param string \$user does not accept actual type of parameter\: int\<min, \-1\>\|int\<1, max\>\|false\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: includes/class-wp-document-revisions.php
 
 		-
 			message: '#^Action callback returns string but should not return anything\.$#'
@@ -163,36 +139,6 @@ parameters:
 			path: includes/class-wp-document-revisions.php
 
 		-
-			message: '#^Parameter \#1 \$post of function wp_check_post_lock expects int\|WP_Post, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Parameter \#1 \$post of function wp_set_post_lock expects int\|WP_Post, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Parameter \#1 \$post_id of method WP_Document_Revisions\:\:send_override_notice\(\) expects int, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Parameter \#1 \$user_id of function get_userdata expects int, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Parameter \#2 \$gmt of function get_post_modified_time expects bool, null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/class-wp-document-revisions.php
-
-		-
 			message: '#^Strict comparison using \=\=\= between null and \*NEVER\* will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
 			count: 1
@@ -209,9 +155,3 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: includes/class-wp-document-revisions.php
-
-		-
-			message: '#^Parameter \#1 \$timezone of function get_lastpostmodified expects ''blog''\|''gmt''\|''server'', ''GMT'' given\.$#'
-			identifier: argument.type
-			count: 1
-			path: includes/revision-feed.php


### PR DESCRIPTION
## Summary

Second phase of the PHPStan level-5 baseline burn-down (follows #611), working the **behavioral tier** tracked in #612. Takes `phpstan-baseline.neon` from **39 → 6** suppressed errors (4 entries remaining). Every change verified against the WordPress PHPUnit suite; the risky items are committed in isolation for review.

Three risk-tiered commits:

1. **`dc27703` — genuine bug + lock/type fixes.** The headline is a real bug: after the merge-revisions `UPDATE`, `clean_post_cache()` was called with `self::$last_revn_excerpt` (the excerpt *text*) instead of `$doc_id`, so the document's cache was never cleared. Plus `override_lock()` passed a string `post_id` to the int-typed lock functions, and the `document_lock_check` filter's `$user` was mis-typed.
2. **`99a7d94` — widget docblocks.** `@param Object` → `array` on the Recently Revised widget methods (every body uses array access exclusively; matches the `WP_Widget` parent contract). Docblock-only.
3. **`444fcff` — remaining behavioral errors.** Another real bug (`$comp_type` could be undefined when `document_serve_use_gzip` forces compression without client negotiation → PHP warning); `post_type_link`/`post_link` are filters wrongly registered via `add_action`; `parse_query` is an action wrongly registered via `add_filter`; a callback `accepted_args` overcount; and behavior-preserving type/contract corrections (`get_revisions()` → `array()`, dead `is_array`/`null` guards removed, scalar casts, docblock fixes).

## Deliberately left baselined (4 entries)

Per review, forcing these to zero would bury bugs or delete correct code:
- **file-handler `deadCode ×3`** — the `$wp_query->is_404 = true; return false;` lines after `wp_die()` marked `// for unit testing`.
- **`booleanAnd.leftAlwaysTrue` on `is_main_site()`** — a real runtime multisite check that phpstan-wordpress's stub treats as constant; deleting it would break sub-site upload dirs.
- **`get_term()` with a shortcode term** that may be a slug or an ID — a blind `(int)` cast would mask the slug case.
- **`wp_dropdown_users()`** with an intentional custom filter arg (`wpdr_added`) the stub doesn't model.

## Verification

- ✅ Full WordPress PHPUnit suite green on **PHP 8.2, single-site and multisite**: 398 tests, 3612 assertions.
- ✅ PHPStan `phpstan.neon.dist` (real config) green; baseline regenerated as deletions only, no float drift.
- ✅ `php -l` + phpcs clean on changed files.

Closes most of #612 (the 4 baselined items remain documented there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
