### PR TITLE
Raise PHPStan to level 6 (array/return type annotations)

### DIFF
--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @method bool verify_post_type( $documentish = false )
  * @method WP_Post|false get_document( $post_id )
- * @method array get_documents( ?array $args = array(), bool $return_attachments = false )
+ * @method WP_Post[] get_documents( ?array<string, mixed> $args = array(), bool $return_attachments = false )
  * @method string format_doc_id( int $post_id )
  * @method string document_upload_dir()
  * @method string document_slug()
@@ -146,8 +146,8 @@ class WP_Document_Revisions_Admin {
 	 * Provides support to call functions of the parent class natively.
 	 *
 	 * @since 1.0
-	 * @param string $funct the function to call.
-	 * @param array  $args  the arguments to pass to the function.
+	 * @param string  $funct the function to call.
+	 * @param mixed[] $args  the arguments to pass to the function.
 	 * @return mixed the result of the function.
 	 */
 	public function __call( $funct, array $args ) {

--- a/includes/class-wp-document-revisions-front-end.php
+++ b/includes/class-wp-document-revisions-front-end.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * forwards to the parent. The `@method` tag below documents that forwarding so
  * static analysis can resolve the call; it adds no runtime behavior.
  *
- * @method array get_revisions( ?int $post_id )
+ * @method WP_Post[] get_revisions( ?int $post_id )
  */
 class WP_Document_Revisions_Front_End {
 
@@ -40,7 +40,7 @@ class WP_Document_Revisions_Front_End {
 	/**
 	 * Array of accepted shortcode keys and default values.
 	 *
-	 * @var array
+	 * @var array<string, mixed>
 	 */
 	public $shortcode_defaults = array(
 		'id'          => null,
@@ -82,8 +82,8 @@ class WP_Document_Revisions_Front_End {
 	 * Provides support to call functions of the parent class natively.
 	 *
 	 * @since 1.2
-	 * @param string $funct the function to call.
-	 * @param array  $args  the arguments to pass to the function.
+	 * @param string  $funct the function to call.
+	 * @param mixed[] $args  the arguments to pass to the function.
 	 * @return mixed the result of the function
 	 */
 	public function __call( string $funct, array $args ) {
@@ -106,7 +106,7 @@ class WP_Document_Revisions_Front_End {
 	/**
 	 * Callback to display revisions.
 	 *
-	 * @param array $atts attributes passed via short code.
+	 * @param array<string, mixed> $atts attributes passed via short code.
 	 * @return string a UL with the revisions
 	 * @since 1.2
 	 */
@@ -180,14 +180,14 @@ class WP_Document_Revisions_Front_End {
 		foreach ( $revisions as $revision ) {
 			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
-			<li class="revision revision-<?php echo esc_attr( $revision->ID ); ?>" >
+			<li class="revision revision-<?php echo esc_attr( (string) $revision->ID ); ?>" >
 				<?php
 				// html - string not to be translated.
 				printf( '<a href="%1$s" title="%2$s" id="%3$s" class="timestamp"', esc_url( get_permalink( $revision->ID ) ), esc_attr( $revision->post_modified ), esc_html( (string) strtotime( $revision->post_modified ) ) );
 				echo ( $atts_new_tab ? ' target="_blank"' : '' );
 				printf( '>%s</a> <span class="agoby">', esc_html( human_time_diff( strtotime( $revision->post_modified_gmt ), time() ) ) . wp_kses_post( $atts_show_pdf ) );
 				esc_html_e( 'ago by', 'wp-document-revisions' );
-				printf( '</span> <span class="author">%s</span>', esc_html( get_the_author_meta( 'display_name', $revision->post_author ) ) );
+				printf( '</span> <span class="author">%s</span>', esc_html( get_the_author_meta( 'display_name', (int) $revision->post_author ) ) );
 				echo ( $atts_summary ? '<br/>' . esc_html( $revision->post_excerpt ) : '' );
 				?>
 			</li>
@@ -207,7 +207,7 @@ class WP_Document_Revisions_Front_End {
 	 * Called from shortcode sirectly.
 	 *
 	 * @since 3.3
-	 * @param array $atts shortcode attributes.
+	 * @param array<string, mixed> $atts shortcode attributes.
 	 * @return string the shortcode output
 	 */
 	public function documents_shortcode( $atts ): string {
@@ -238,7 +238,7 @@ class WP_Document_Revisions_Front_End {
 	 * reuse of workflow_state when EditLlow or PublishPressi is used.
 	 *
 	 * @since 1.2
-	 * @param array $atts shortcode attributes.
+	 * @param array<string, mixed> $atts shortcode attributes.
 	 * @return string the shortcode output
 	 */
 	private function documents_shortcode_int( array $atts ): string {
@@ -552,6 +552,7 @@ class WP_Document_Revisions_Front_End {
 	 * @since 3.3.0
 	 * @param mixed[]                  $categories           Block categories available.
 	 * @param ?WP_Block_Editor_Context $block_editor_context The current block editor context.
+	 * @return mixed[] the (possibly extended) block categories.
 	 */
 	public function wpdr_block_categories( array $categories, ?WP_Block_Editor_Context $block_editor_context = null ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 
@@ -648,7 +649,7 @@ class WP_Document_Revisions_Front_End {
 	/**
 	 * Flattened taxonomy term list.
 	 *
-	 * @var array $tax_terms array of terms.
+	 * @var array<int|string, mixed> $tax_terms array of terms.
 	 */
 	private static $tax_terms = array();
 
@@ -780,7 +781,7 @@ class WP_Document_Revisions_Front_End {
 	/**
 	 * Server side block to render the documents list.
 	 *
-	 * @param array $atts shortcode attributes.
+	 * @param array<string, mixed> $atts shortcode attributes.
 	 * @return string a UL with the revisions
 	 * @since 3.3.0
 	 */
@@ -922,7 +923,7 @@ class WP_Document_Revisions_Front_End {
 	/**
 	 * Server side block to render the revisions list.
 	 *
-	 * @param array $atts shortcode attributes.
+	 * @param array<string, mixed> $atts shortcode attributes.
 	 * @return string a UL with the revisions
 	 * @since 3.3.0
 	 */

--- a/includes/class-wp-document-revisions-manage-rest.php
+++ b/includes/class-wp-document-revisions-manage-rest.php
@@ -66,8 +66,8 @@ class WP_Document_Revisions_Manage_Rest {
 	 *
 	 * @since 3.4.0
 	 *
-	 * @param string $funct the function to call.
-	 * @param array  $args  the arguments to pass to the function.
+	 * @param string  $funct the function to call.
+	 * @param mixed[] $args  the arguments to pass to the function.
 	 * @return mixed the result of the function.
 	 */
 	public function __call( string $funct, array $args ) {
@@ -80,8 +80,9 @@ class WP_Document_Revisions_Manage_Rest {
 	 * @since 3.4.0
 	 * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response Result to send to the client.
 	 *                                                                   Usually a WP_REST_Response or WP_Error.
-	 * @param array                                            $handler  Route handler used for the request.
+	 * @param array<string, mixed>                             $handler  Route handler used for the request.
 	 * @param WP_REST_Request                                  $request  Request used to generate the response.
+	 * @return WP_REST_Response|WP_HTTP_Response|WP_Error|mixed the (possibly modified) response.
 	 **/
 	public static function document_validation( $response, array $handler, WP_REST_Request $request ) {
 		if ( is_wp_error( $response ) ) {
@@ -177,6 +178,7 @@ class WP_Document_Revisions_Manage_Rest {
 	 * @param WP_REST_Response|WP_Error $response The response object (or error if found).
 	 * @param WP_Post                   $post     Post object.
 	 * @param WP_REST_Request           $request  Request object.
+	 * @return WP_REST_Response|WP_Error the cleaned response.
 	 */
 	public function doc_clean_document( $response, WP_Post $post, WP_REST_Request $request ) {
 		// Already filtered to an error response.
@@ -237,6 +239,7 @@ class WP_Document_Revisions_Manage_Rest {
 	 * @param WP_REST_Response|WP_Error $response The response object (or error if found).
 	 * @param WP_Post                   $post     Post object.
 	 * @param WP_REST_Request           $request  Request object.
+	 * @return WP_REST_Response|WP_Error the cleaned response.
 	 */
 	public function doc_clean_revision( $response, WP_Post $post, WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		// Already filtered to an error response.
@@ -277,6 +280,7 @@ class WP_Document_Revisions_Manage_Rest {
 	 * @param WP_REST_Response|WP_Error $response The response object (or error if found).
 	 * @param WP_Post                   $post     Post object.
 	 * @param WP_REST_Request           $request  Request object.
+	 * @return WP_REST_Response|WP_Error the cleaned response.
 	 */
 	public function doc_clean_attachment( $response, WP_Post $post, WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		// Already filtered to an error response.

--- a/includes/class-wp-document-revisions-recently-revised-widget.php
+++ b/includes/class-wp-document-revisions-recently-revised-widget.php
@@ -18,7 +18,7 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	/**
 	 * The default data
 	 *
-	 * @var array
+	 * @var array<string, mixed>
 	 */
 	public $defaults = array(
 		'title'       => '',
@@ -47,8 +47,9 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	/**
 	 * Generate widget contents.
 	 *
-	 * @param mixed[] $args the widget arguments.
-	 * @param array   $instance the WP Document Revisions instance.
+	 * @param mixed[]              $args the widget arguments.
+	 * @param array<string, mixed> $instance the WP Document Revisions instance.
+	 * @return string|false the widget markup, or false on buffering failure.
 	 */
 	public function widget_gen( array $args, $instance ) {
 		global $wpdr;
@@ -171,8 +172,9 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	/**
 	 * Callback to display widget contents in classic widget.
 	 *
-	 * @param array $args the widget arguments.
-	 * @param array $instance the WP Document Revisions instance.
+	 * @param array<string, mixed> $args the widget arguments.
+	 * @param array<string, mixed> $instance the WP Document Revisions instance.
+	 * @return void
 	 */
 	public function widget( $args, $instance ) {
 
@@ -185,7 +187,7 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	/**
 	 * Callback to display widget options form.
 	 *
-	 * @param array $instance the WP Document Revisions instance.
+	 * @param array<string, mixed> $instance the WP Document Revisions instance.
 	 */
 	public function form( $instance ) {
 
@@ -237,8 +239,9 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	/**
 	 * Sanitizes options and saves.
 	 *
-	 * @param array $new_instance the new instance.
-	 * @param array $old_instance the old instance.
+	 * @param array<string, mixed> $new_instance the new instance.
+	 * @param array<string, mixed> $old_instance the old instance.
+	 * @return array<string, mixed> the sanitized instance to save.
 	 */
 	public function update( $new_instance, $old_instance ) {
 
@@ -327,9 +330,10 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	/**
 	 * Render widget block server side.
 	 *
-	 * @param array  $atts     block attributes coming from block.
-	 * @param string $content  Optional. Block content. Default empty string.
+	 * @param array<string, mixed> $atts     block attributes coming from block.
+	 * @param string               $content  Optional. Block content. Default empty string.
 	 * @since 3.3.0
+	 * @return string the rendered block markup.
 	 */
 	public function wpdr_documents_widget_display( array $atts, string $content = '' ) {
 		// Create the two parameter sets.

--- a/includes/class-wp-document-revisions-validate-structure.php
+++ b/includes/class-wp-document-revisions-validate-structure.php
@@ -198,8 +198,8 @@ class WP_Document_Revisions_Validate_Structure {
 	 *
 	 * @since 3.4.0
 	 *
-	 * @param string $funct the function to call.
-	 * @param array  $args  the arguments to pass to the function.
+	 * @param string  $funct the function to call.
+	 * @param mixed[] $args  the arguments to pass to the function.
 	 * @return mixed the result of the function.
 	 */
 	public function __call( $funct, array $args ) {
@@ -742,7 +742,7 @@ class WP_Document_Revisions_Validate_Structure {
 	 * @param int    $doc_id            ID of a post object.
 	 * @param int    $attach_id         attachment id from post content field.
 	 * @param string $post_modified_gmt post modified field.
-	 * @return array|false
+	 * @return array<int|string, mixed>|false
 	 */
 	private static function validate_document( $doc_id, $attach_id, string $post_modified_gmt ) {
 		global $wpdb;
@@ -836,7 +836,7 @@ class WP_Document_Revisions_Validate_Structure {
 	 * @param string $post_date   post date field.
 	 * @param string $post_name   post name field.
 	 * @param string $guid        post guid field.
-	 * @return array|bool
+	 * @return array<int|string, mixed>|bool
 	 */
 	private static function validate_guid( $doc_id, $attach_id, string $post_status, string $post_date, string $post_name, string $guid ) {
 		$msg_09 = esc_html__( 'The guid is not the expected "ugly" permalink', 'wp-document-revisions' );

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -40,7 +40,7 @@ class WP_Document_Revisions {
 	/**
 	 * The WP default upload directory cache.
 	 *
-	 * @var array
+	 * @var array<string, mixed>
 	 *
 	 * @since 3.2
 	 */
@@ -451,8 +451,8 @@ class WP_Document_Revisions {
 	 * Ability callback: Check if the current user can perform an action on a document.
 	 *
 	 * @since 3.9.1
-	 * @param array $input Input containing document_id and action.
-	 * @return array Result with 'allowed' boolean.
+	 * @param array<string, mixed> $input Input containing document_id and action.
+	 * @return array<string, mixed> Result with 'allowed' boolean.
 	 */
 	public function ability_check_document_access( array $input ): array {
 		$document_id = (int) $input['document_id'];
@@ -486,8 +486,8 @@ class WP_Document_Revisions {
 	 * Ability callback: Get document metadata.
 	 *
 	 * @since 3.9.1
-	 * @param array $input Input containing document_id.
-	 * @return array|WP_Error Document info or error.
+	 * @param array<string, mixed> $input Input containing document_id.
+	 * @return array<string, mixed>|WP_Error Document info or error.
 	 */
 	public function ability_get_document_info( array $input ) {
 		$document_id = (int) $input['document_id'];
@@ -526,8 +526,8 @@ class WP_Document_Revisions {
 	 * Ability callback: Get document revision history.
 	 *
 	 * @since 3.9.1
-	 * @param array $input Input containing document_id.
-	 * @return array|WP_Error Revision list or error.
+	 * @param array<string, mixed> $input Input containing document_id.
+	 * @return array<string, mixed>|WP_Error Revision list or error.
 	 */
 	public function ability_get_document_revisions( array $input ) {
 		$document_id = (int) $input['document_id'];
@@ -562,7 +562,7 @@ class WP_Document_Revisions {
 
 		if ( is_array( $revisions ) ) {
 			foreach ( $revisions as $revision ) {
-				$author   = get_userdata( $revision->post_author );
+				$author   = get_userdata( (int) $revision->post_author );
 				$result[] = array(
 					'id'     => $revision->ID,
 					'date'   => $revision->post_date,
@@ -579,8 +579,8 @@ class WP_Document_Revisions {
 	 * Ability callback: Override a document lock.
 	 *
 	 * @since 3.9.1
-	 * @param array $input Input containing document_id.
-	 * @return array|WP_Error Result or error.
+	 * @param array<string, mixed> $input Input containing document_id.
+	 * @return array<string, mixed>|WP_Error Result or error.
 	 */
 	public function ability_override_document_lock( array $input ) {
 		$document_id = (int) $input['document_id'];

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -19,9 +19,9 @@ if ( ! function_exists( 'get_documents' ) ) {
 	 * Takes standard WP_Query parameters
 	 * See in-line documentation in wp-document-revisions.php for more information ( function get_documents() )
 	 *
-	 * @param array $args WP_Query parameters.
-	 * @param bool  $return_attachments whether to return attachment or revisions objects.
-	 * @return array array of post objects
+	 * @param array<string, mixed> $args WP_Query parameters.
+	 * @param bool                 $return_attachments whether to return attachment or revisions objects.
+	 * @return WP_Post[] array of post objects
 	 */
 	function get_documents( array $args = array(), bool $return_attachments = false ): array { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 
@@ -42,7 +42,7 @@ if ( ! function_exists( 'get_document_revisions' ) ) {
 	 * See in-line documentation in wp-document-revisions.php for more information ( function get_revisions() )
 	 *
 	 * @param int $document_id the ID of the document.
-	 * @return array array of revision-post objects
+	 * @return WP_Post[] array of revision-post objects
 	 */
 	function get_document_revisions( int $document_id ): array { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
 

--- a/includes/trait-wp-document-revisions-admin-editor.php
+++ b/includes/trait-wp-document-revisions-admin-editor.php
@@ -33,8 +33,8 @@ trait WP_Document_Revisions_Admin_Editor {
 	 * Registers update messages
 	 *
 	 * @since 0.5
-	 * @param array $messages messages array.
-	 * @return array messages array with doc. messages
+	 * @param array<string, mixed> $messages messages array.
+	 * @return array<string, mixed> messages array with doc. messages
 	 */
 	public function update_messages( array $messages ): array {
 		global $post, $post_id;
@@ -143,9 +143,9 @@ trait WP_Document_Revisions_Admin_Editor {
 	 * Forces postcustom metabox to be hidden by default, despite the fact that the CPT creates it.
 	 *
 	 * @since 1.0
-	 * @param array      $hidden the default hidden metaboxes.
+	 * @param string[]   $hidden the default hidden metaboxes.
 	 * @param ?WP_Screen $screen the current screen.
-	 * @return array defaults with postcustom
+	 * @return string[] defaults with postcustom
 	 */
 	public function hide_postcustom_metabox( array $hidden, ?WP_Screen $screen ): array {
 		if ( $screen && 'document' === $screen->id ) {
@@ -268,12 +268,12 @@ trait WP_Document_Revisions_Admin_Editor {
 	 *
 	 * @since 0.5
 	 *
-	 * @param int    $doc_id     the document ID.
-	 * @param array  $terms      the new terms.
-	 * @param array  $tt_ids     the new term IDs.
-	 * @param string $taxonomy   the taxonomy being changed.
-	 * @param bool   $append     whether it is being appended or replaced.
-	 * @param array  $old_tt_ids term taxonomy ID array before the change.
+	 * @param int     $doc_id     the document ID.
+	 * @param mixed[] $terms      the new terms.
+	 * @param int[]   $tt_ids     the new term IDs.
+	 * @param string  $taxonomy   the taxonomy being changed.
+	 * @param bool    $append     whether it is being appended or replaced.
+	 * @param int[]   $old_tt_ids term taxonomy ID array before the change.
 	 */
 	public function workflow_state_save( int $doc_id, array $terms, array $tt_ids, string $taxonomy, bool $append, array $old_tt_ids ): void {
 		// Only interested in replacement to this taxonomy, so if not, bail early.
@@ -336,9 +336,9 @@ trait WP_Document_Revisions_Admin_Editor {
 	 * the data in-place without a secondary wp_update_post call.
 	 *
 	 * @since 4.0.8
-	 * @param array $data    Sanitized post data about to be inserted.
-	 * @param array $postarr Raw post data passed to wp_insert_post.
-	 * @return array Post data, with post_content restored if needed.
+	 * @param array<string, mixed> $data    Sanitized post data about to be inserted.
+	 * @param array<string, mixed> $postarr Raw post data passed to wp_insert_post.
+	 * @return array<string, mixed> Post data, with post_content restored if needed.
 	 */
 	public function restore_document_attachment_id( array $data, array $postarr ): array {
 		if ( 'document' !== $data['post_type'] ) {
@@ -750,7 +750,7 @@ trait WP_Document_Revisions_Admin_Editor {
 	 *
 	 * @since 1.1
 	 * @param WP_Screen $screen (optional) the current screen.
-	 * @return array the help text
+	 * @return array<string, mixed> the help text
 	 */
 	public function get_help_text( ?WP_Screen $screen = null ): array {
 		if ( is_null( $screen ) ) {
@@ -806,6 +806,7 @@ trait WP_Document_Revisions_Admin_Editor {
 	 *
 	 * @param bool    $use_block_editor Whether the post can be edited or not.
 	 * @param WP_Post $post             The post being checked.
+	 * @return bool whether the post can use the block editor.
 	 */
 	public function no_use_block_editor( bool $use_block_editor, WP_Post $post ) {
 		$wpdr = self::$parent;
@@ -849,9 +850,10 @@ trait WP_Document_Revisions_Admin_Editor {
 	 *
 	 * @since 3.4.0
 	 *
-	 * @param array  $settings  Array of editor arguments.
-	 * @param string $editor_id Unique editor identifier, e.g. 'content'. Accepts 'classic-block'
-	 *                          when called from block editor's Classic block.
+	 * @param array<string, mixed> $settings  Array of editor arguments.
+	 * @param string               $editor_id Unique editor identifier, e.g. 'content'. Accepts 'classic-block'
+	 *                                         when called from block editor's Classic block.
+	 * @return array<string, mixed> the (possibly modified) editor settings.
 	 */
 	public function document_editor_setting( array $settings, string $editor_id ) {
 		// only interested in content.
@@ -880,7 +882,8 @@ trait WP_Document_Revisions_Admin_Editor {
 	 *
 	 * @since 3.4.0
 	 *
-	 * @param array $settings  Array of tiny_mce arguments.
+	 * @param array<string, mixed> $settings  Array of tiny_mce arguments.
+	 * @return array<string, mixed> the (possibly modified) tiny_mce arguments.
 	 */
 	public function modify_content_class( array $settings ) {
 		// check on document only affects these.
@@ -911,6 +914,7 @@ trait WP_Document_Revisions_Admin_Editor {
 	 * to style the page (e.g., when the document is locked).
 	 *
 	 * @param String $body_class the existing body class(es).
+	 * @return string the (possibly modified) body class(es).
 	 */
 	public function admin_body_class_filter( string $body_class ) {
 		global $post;

--- a/includes/trait-wp-document-revisions-admin-list.php
+++ b/includes/trait-wp-document-revisions-admin-list.php
@@ -67,8 +67,9 @@ trait WP_Document_Revisions_Admin_List {
 	 * Filter the user dropdown args to add additional arguments that are normally filtered out. .
 	 *
 	 * @since 3.6
-	 * @param array $query_args  The query arguments for get_users().
-	 * @param array $parsed_args The arguments passed to wp_dropdown_users() combined with the defaults.
+	 * @param array<string, mixed> $query_args  The query arguments for get_users().
+	 * @param array<string, mixed> $parsed_args The arguments passed to wp_dropdown_users() combined with the defaults.
+	 * @return array<string, mixed> the (possibly modified) query arguments.
 	 */
 	public function filter_user_dropdown( array $query_args, array $parsed_args ) {
 		if ( array_key_exists( 'wpdr_added', $parsed_args ) ) {
@@ -112,8 +113,8 @@ trait WP_Document_Revisions_Admin_List {
 	 * Renames author column on document list to "owner".
 	 *
 	 * @since 1.0.4
-	 * @param array $defaults the default column labels.
-	 * @return array the modified column labels
+	 * @param array<string, string> $defaults the default column labels.
+	 * @return array<string, string> the modified column labels
 	 */
 	public function rename_author_column( array $defaults ): array {
 		if ( isset( $defaults['author'] ) ) {
@@ -127,8 +128,8 @@ trait WP_Document_Revisions_Admin_List {
 	 * Splices in Currently Editing column to document list.
 	 *
 	 * @since 1.1
-	 * @param array $defaults the original columns.
-	 * @return array our spliced columns
+	 * @param array<string, string> $defaults the original columns.
+	 * @return array<string, string> our spliced columns
 	 */
 	public function add_currently_editing_column( array $defaults ): array {
 		// get checkbox and title.

--- a/includes/trait-wp-document-revisions-admin-settings.php
+++ b/includes/trait-wp-document-revisions-admin-settings.php
@@ -323,7 +323,7 @@ trait WP_Document_Revisions_Admin_Settings {
 				printf(
 					esc_html( $format_string ),
 					esc_html( human_time_diff( strtotime( $document->post_modified_gmt ), time() ) ),
-					esc_html( get_the_author_meta( 'display_name', $document->post_author ) ),
+					esc_html( get_the_author_meta( 'display_name', (int) $document->post_author ) ),
 					esc_html( ucwords( $document->post_status ) )
 				);
 				?>
@@ -719,8 +719,8 @@ trait WP_Document_Revisions_Admin_Settings {
 	 * Filters documents from the media grid view when queried via Ajax. This uses
 	 * the same filters from the list view applied in `filter_from_media()`.
 	 *
-	 * @param array $query the attachment query arguments.
-	 * @return array
+	 * @param array<string, mixed> $query the attachment query arguments.
+	 * @return array<string, mixed>
 	 */
 	public function filter_from_media_grid( array $query ) {
 		// note: hook late so that unattached filter can hook in, if necessary.
@@ -771,6 +771,7 @@ trait WP_Document_Revisions_Admin_Settings {
 	 *
 	 * @since 0.5
 	 * @param string $file Path to the file to delete.
+	 * @return string the (possibly remapped) file path.
 	 */
 	public function wp_delete_file( string $file ) {
 		global $wpdr;
@@ -785,6 +786,8 @@ trait WP_Document_Revisions_Admin_Settings {
 	/**
 	 * Remove all hooks that activate workflow state support
 	 * use filter `document_use_workflow_states` to disable.
+	 *
+	 * @return bool false if workflow states remain enabled, true once disabled.
 	 */
 	public function disable_workflow_states() {
 		if ( self::$parent->use_workflow_states() ) {

--- a/includes/trait-wp-document-revisions-file-handler.php
+++ b/includes/trait-wp-document-revisions-file-handler.php
@@ -577,8 +577,8 @@ trait WP_Document_Revisions_File_Handler {
 	 * Rewrites uploaded revisions filename with secure hash to mask true location.
 	 *
 	 * @since 0.5
-	 * @param array $file file data from WP.
-	 * @return array $file file with new filename
+	 * @param array<string, mixed> $file file data from WP.
+	 * @return array<string, mixed> file with new filename
 	 */
 	public function filename_rewrite( array $file ): array {
 		// verify if this is a document load as they have an additional parameter.
@@ -655,10 +655,11 @@ trait WP_Document_Revisions_File_Handler {
 	 *
 	 * @since 3.4.0.
 	 *
-	 * @param array  $metadata      An array of attachment meta data.
-	 * @param int    $attachment_id Current attachment ID.
-	 * @param string $context       Additional context. Can be 'create' when metadata was initially created for new attachment
-	 *                              or 'update' when the metadata was updated.
+	 * @param array<string, mixed> $metadata      An array of attachment meta data.
+	 * @param int                  $attachment_id Current attachment ID.
+	 * @param string               $context       Additional context. Can be 'create' when metadata was initially created for new attachment
+	 *                                             or 'update' when the metadata was updated.
+	 * @return array<string, mixed> the (possibly modified) attachment metadata.
 	 */
 	public function hide_doc_attach_slug( array $metadata, int $attachment_id, string $context ): array {  // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		// check that for a document.
@@ -965,8 +966,8 @@ trait WP_Document_Revisions_File_Handler {
 	 * Modifies location of uploaded document revisions.
 	 *
 	 * @since 0.5
-	 * @param array $dir defaults passed from WP.
-	 * @return array $dir modified directory
+	 * @param array<string, mixed> $dir defaults passed from WP.
+	 * @return array<string, mixed> modified directory
 	 */
 	public function document_upload_dir_filter( array $dir ): array {
 		if ( ! $this->verify_post_type() ) {
@@ -989,8 +990,8 @@ trait WP_Document_Revisions_File_Handler {
 	 *
 	 * @since 3.5.0
 	 *
-	 * @param array $dir defaults passed from WP.
-	 * @return array $dir document directory
+	 * @param array<string, mixed> $dir defaults passed from WP.
+	 * @return array<string, mixed> document directory
 	 */
 	public function document_upload_dir_set( array $dir ): array {
 
@@ -1232,10 +1233,10 @@ trait WP_Document_Revisions_File_Handler {
 	 * Will also check to make sure the returned image doesn't leak the file's true path.
 	 *
 	 * @since 1.2.2
-	 * @param bool|array $downsize Whether to short-circuit the image downsize.
-	 * @param int        $id       the ID of the attachment.
-	 * @param string     $size     the size requested.
-	 * @return bool|array false or the image array to be returned from image_downsize()
+	 * @param bool|array<int, mixed> $downsize Whether to short-circuit the image downsize.
+	 * @param int                    $id       the ID of the attachment.
+	 * @param string                 $size     the size requested.
+	 * @return bool|array<int, mixed> false or the image array to be returned from image_downsize()
 	 */
 	public function image_downsize( $downsize, $id, $size ) {
 		$id = (int) $id;

--- a/includes/trait-wp-document-revisions-query.php
+++ b/includes/trait-wp-document-revisions-query.php
@@ -40,9 +40,9 @@ trait WP_Document_Revisions_Query {
 	 *
 	 * See https://developer.wordpress.org/reference/classes/wp_query/ for more information on potential parameters
 	 *
-	 * @param ?array  $args (optional) an array of WP_Query arguments.
-	 * @param boolean $return_attachments (optional).
-	 * @return array an array of post objects
+	 * @param ?array<string, mixed> $args (optional) an array of WP_Query arguments.
+	 * @param boolean               $return_attachments (optional).
+	 * @return WP_Post[] an array of post objects
 	 */
 	public function get_documents( ?array $args = array(), bool $return_attachments = false ): array {
 		$args              = (array) $args;
@@ -289,6 +289,7 @@ trait WP_Document_Revisions_Query {
 	 * @since 3.3.0
 	 * @param string[]    $statuses  List of post statuses to include in the count. Default is 'publish'.
 	 * @param WP_Taxonomy $taxonomy  Current taxonomy object.
+	 * @return string[] the (possibly modified) list of post statuses.
 	 */
 	public function review_count_statuses( array $statuses, WP_Taxonomy $taxonomy ): array {
 		$tax_name   = $taxonomy->name;
@@ -418,6 +419,7 @@ trait WP_Document_Revisions_Query {
 	 * @param string|int[] $size    Requested image size. Can be any registered image size name, or
 	 *                              an array of width and height values in pixels (in that order).
 	 * @param int          $post_id The post ID.
+	 * @return string|array<int, mixed> the (possibly overridden) image size.
 	 */
 	public function document_featured_image_size( $size, int $post_id ) {
 		if ( 'post-thumbnail' !== $size || ! $this->verify_post_type( $post_id ) ) {
@@ -472,7 +474,7 @@ trait WP_Document_Revisions_Query {
 	 *
 	 * @param string       $where          The `WHERE` clause in the SQL.
 	 * @param bool         $in_same_term   Whether post should be in a same taxonomy term.
-	 * @param array|string $excluded_terms Array of excluded term IDs, or comma-separated string.
+	 * @param int[]|string $excluded_terms Array of excluded term IDs, or comma-separated string.
 	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
 	 * @param WP_Post      $post           WP_Post object.
 	 *
@@ -544,8 +546,8 @@ trait WP_Document_Revisions_Query {
 	 * Adds EditFlow / PublishPress Status support for post status to the admin table.
 	 *
 	 * @since 3.3.0
-	 * @param array $defaults the column chosen of the all documents list.
-	 * @return array the updated column list.
+	 * @param array<string, string> $defaults the column chosen of the all documents list.
+	 * @return array<string, string> the updated column list.
 	 */
 	public function add_post_status_column( array $defaults ): array {
 		// find place to slice (after author).

--- a/includes/trait-wp-document-revisions-revisions.php
+++ b/includes/trait-wp-document-revisions-revisions.php
@@ -32,7 +32,7 @@ trait WP_Document_Revisions_Revisions {
 	 *
 	 * @since 1.0
 	 * @param ?int $post_id the post ID.
-	 * @return array array of post objects
+	 * @return WP_Post[] array of post objects
 	 */
 	public function get_revisions( ?int $post_id ) {
 		$document = get_post( $post_id );
@@ -149,7 +149,7 @@ trait WP_Document_Revisions_Revisions {
 
 			$latest_attachment = reset( $attachments );
 			if ( is_numeric( $revisions[0]->post_content ) ) {
-				$revisions[0]->post_content = $this->format_doc_id( $revisions[0]->post_content );
+				$revisions[0]->post_content = $this->format_doc_id( (int) $revisions[0]->post_content );
 			} elseif ( empty( $revisions[0]->post_content ) ) {
 				$revisions[0]->post_content = $this->format_doc_id( $latest_attachment->ID );
 			}
@@ -333,7 +333,7 @@ trait WP_Document_Revisions_Revisions {
 	 *
 	 * @since 0.5
 	 * @param int $post_id the parent post id.
-	 * @return array array of revisions
+	 * @return int[] 1-indexed array of revision post IDs
 	 */
 	public function get_revision_indices( int $post_id ): array {
 		$cache = wp_cache_get( $post_id, 'document_revision_indices' );

--- a/includes/trait-wp-document-revisions-rewrites.php
+++ b/includes/trait-wp-document-revisions-rewrites.php
@@ -151,8 +151,8 @@ trait WP_Document_Revisions_Rewrites {
 	 * Tells WP to recognize document query vars.
 	 *
 	 * @since 0.5
-	 * @param array $vars the query vars.
-	 * @return array the modified query vars
+	 * @param string[] $vars the query vars.
+	 * @return string[] the modified query vars
 	 */
 	public function add_query_var( array $vars ): array {
 		$vars[] = 'revision';
@@ -253,8 +253,8 @@ trait WP_Document_Revisions_Rewrites {
 	 * Rewrites a file URL to its public URL.
 	 *
 	 * @since 0.5
-	 * @param array $file file object from WP.
-	 * @return array modified file array
+	 * @param array<string, mixed> $file file object from WP.
+	 * @return array<string, mixed> modified file array
 	 */
 	public function rewrite_file_url( array $file ): array {
 		// verify this is a document load as self::$doc_image has been set false if a WPDR document.
@@ -284,8 +284,8 @@ trait WP_Document_Revisions_Rewrites {
 	 * Tells WP to recognize workflow_state as a query vars.
 	 *
 	 * @since 3.3.0
-	 * @param array $vars the query vars.
-	 * @return array the modified query vars
+	 * @param string[] $vars the query vars.
+	 * @return string[] the modified query vars
 	 */
 	public function add_qv_workflow_state( array $vars ): array {
 		$vars[] = 'workflow_state';

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Action callback returns bool but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: includes/class-wp-document-revisions-admin.php
+
+		-
 			message: '#^Parameter \#1 \$args of function wp_dropdown_users expects array\{show_option_all\?\: string, show_option_none\?\: string, option_none_value\?\: int\|string, hide_if_only_one_author\?\: string, orderby\?\: array\|string, order\?\: string, include\?\: array\<int\>\|string, exclude\?\: array\<int\>\|string, \.\.\.\}, array\{name\: ''author'', show_option_all\: string, value_field\: ''slug'', selected\: string\|false\|null, orderby\: ''name'', order\: ''ASC'', wpdr_added\: ''list'', has_published_posts\: array\{''document''\}\} given\.$#'
 			identifier: argument.type
 			count: 1

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
     paths:
         - wp-document-revisions.php
         - includes/


### PR DESCRIPTION
## Summary

Raises PHPStan from **level 5 to level 6** and resolves the ~99 new findings it surfaces. Almost entirely type-annotation work (docblocks), so **zero runtime behavior change**. Follows the level-5 burn-down (#611, #613).

Level 6's new checks are `missingType.iterableValue` (arrays without a value type) and `missingType.return` (methods without a declared return type):

- **iterableValue** — gave every `array` `@param`/`@return`/`@var`/`@method` its value type, using the known WordPress hook shapes: columns `array<string, string>`, query vars `string[]`, upload/metadata/editor-settings `array<string, mixed>`, term-id lists `int[]`, and `WP_Post[]` for the document/revision getters.
- **return** — added return types to the REST "clean" callbacks (`WP_REST_Response|WP_Error`), the widget methods, the ability callbacks, and assorted filters.

A handful of explicit `(int)` casts were needed where the now-precise `WP_Post[]` return types revealed that `WP_Post::$post_author` / `$post_content` are strings being passed to int-typed functions (`format_doc_id`, `get_userdata`, `get_the_author_meta`) — benign coercions, now explicit.

## Baseline (5 entries, deliberate)

Unchanged from the level-5 residual plus one:
- the three file-handler `// for unit testing` unreachable statements;
- `is_main_site()` `booleanAnd` that phpstan-wordpress's stub treats as constant (a real runtime multisite check);
- `get_term()` with a shortcode term that may be a slug or an ID;
- `wp_dropdown_users()` with an intentional custom filter arg;
- a `return.void` on `disable_workflow_states()`, which legitimately returns `bool` (used at `admin-editor.php:120`) yet is *also* registered as an `init` action callback.

## Verification

- ✅ Full WordPress PHPUnit suite green on **PHP 8.2, single-site and multisite**: 398 tests, 3612 assertions.
- ✅ PHPStan `phpstan.neon.dist` (now `level: 6`) + baseline green; baseline regenerated as additions-only.
- ✅ phpcs (WordPress standard) clean on all changed files.

## Not included

**Level 7** (~212 further errors, mostly union-type / null-safety) is a separate, behavioral effort — intentionally not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
