### PR TITLE
Prepare 5.1.3 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 Numbers in brackets show the issue number in https://github.com/wp-document-revisions/wp-document-revisions/issues/
 
+### 5.1.3
+
+* Fix stale document data after consecutive revisions are merged on save: the document's object cache is now cleared correctly (previously the cache was keyed on the revision excerpt text rather than the document ID, so it was never invalidated). (#613)
+* Fix a fatal error when saving the Document Link Date option on the multisite network settings screen, caused by a call to an undefined sanitization method. (#611)
+* Avoid a PHP warning when serving a document with gzip compression forced via the `document_serve_use_gzip` filter for a client that did not advertise encoding support. (#613)
+
 ### 5.1.2
 
 * Ensure that Live Review document upload works and the media window autocloses after successful upload. (#588)

--- a/docs/header.md
+++ b/docs/header.md
@@ -5,7 +5,7 @@ Tags: documents, document management, version control, collaboration, revisions
 Requires at least: 5.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 5.1.2
+Stable tag: 5.1.3
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: documents, document management, version control, collaboration, revisions
 Requires at least: 5.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 5.1.2
+Stable tag: 5.1.3
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -219,15 +219,17 @@ Interested in translating WP Document Revisions? You can do so [via Crowdin](htt
 
 Numbers in brackets show the issue number in https://github.com/wp-document-revisions/wp-document-revisions/issues/
 
+= 5.1.3 =
+
+* Fix stale document data after consecutive revisions are merged on save: the document's object cache is now cleared correctly (previously the cache was keyed on the revision excerpt text rather than the document ID, so it was never invalidated). (#613)
+* Fix a fatal error when saving the Document Link Date option on the multisite network settings screen, caused by a call to an undefined sanitization method. (#611)
+* Avoid a PHP warning when serving a document with gzip compression forced via the `document_serve_use_gzip` filter for a client that did not advertise encoding support. (#613)
+
 = 5.1.2 =
 
 * Ensure that Live Review document upload works and the media window autocloses after successful upload. (#588)
 * Recover the document's own attachment instead of dropping it when a forged or foreign attachment marker is rejected, preserving the legitimate attachment. Follow-up to the 5.1.1 security fix. (#587)
 
 = 5.1.1 =
-
-* Fix an attachment IDOR where a document editor could forge the attachment marker when saving a document to point it at, and serve, another document's file. The attachment is now verified to belong to the document being saved, matching the check already enforced on the REST save path. Reported via the WordPress.org automated security review. (#584)
-
-= 5.1.0 =
 
 For complete changelog, see [GitHub](https://wp-document-revisions.github.io/wp-document-revisions/changelog/)

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Document Revisions
 Plugin URI: http://ben.balter.com/2011/08/29/wp-document-revisions-document-management-version-control-wordpress/
 Description: A document management and version control plugin for WordPress that allows teams of any size to collaboratively edit files and manage their workflow.
-Version: 5.1.2
+Version: 5.1.3
 Requires at least: 5.9
 Requires PHP: 8.0
 Author: Ben Balter
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  *  @copyright 2011-2026
  *  @license GPL-3.0-or-later
- *  @version 5.1.2
+ *  @version 5.1.3
  *  @package WP_Document_Revisions
  *  @author Ben Balter <ben@balter.com>
  */
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // parsed by WordPress from the file header itself and must remain literal; this
 // constant is the canonical value for runtime PHP code (cache busters, etc.).
 if ( ! defined( 'WPDR_VERSION' ) ) {
-	define( 'WPDR_VERSION', '5.1.2' );
+	define( 'WPDR_VERSION', '5.1.3' );
 }
 
 // Composer autoloader for production dependencies.


### PR DESCRIPTION
## 5.1.3 — bug-fix patch

Prepares the 5.1.3 release. Version bumped across the plugin header, `@version` docblock, and `WPDR_VERSION` constant; `docs/header.md` Stable tag updated; changelog entry added; `readme.txt` rebuilt via `script/build-readme`.

### User-facing fixes (all already on main)

Three fixes that landed during the PHPStan hardening work but are genuinely user-visible:

1. **Stale document cache after revision merge** (#613) — after consecutive revisions were merged on save, the document's object cache was never cleared (it was keyed on the revision *excerpt text* instead of the document ID), so editors could see stale data until expiry. Affects all sites.
2. **Fatal on network Document Link Date save** (#611) — the multisite network-settings save path called an undefined sanitization method. Affects multisite network admins.
3. **PHP warning when serving a document with forced gzip** (#613) — `$comp_type` could be undefined when `document_serve_use_gzip` forces compression for a client that advertised no encoding.

The PHPStan level 5→6 hardening itself is intentionally **not** in the changelog — it's a maintainer concern with no user-visible effect.

### Shipping

Per the release process, merging this PR does **not** deploy — `deploy.yml` runs only on a git **tag** push. After merge, tag `v5.1.3` on main to ship to WordPress.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
