### PR TITLE
Prepare 5.3.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,10 +4,10 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 
 ### 5.3.0
 
-* The WordPress.org "Live Preview" now opens with sample documents that already carry revision history and workflow states, so the preview demonstrates version control and workflow at a glance instead of showing an empty list.
-* Add a first-run prompt on the Documents screen that points new users (and Live Preview visitors) to add their first document, replacing the blank empty-state table.
-* Occasionally invite established users to leave a WordPress.org review — shown only after real, successful use, dismissible, and never repeated once dismissed.
-* Documentation: block editor (Gutenberg) support is now described as supported and opt-in rather than experimental, and the readme leads with the plugin's full-text search and AI-generated revision summary capabilities.
+* The WordPress.org "Live Preview" now opens with sample documents that already carry revision history and workflow states, so the preview demonstrates version control and workflow at a glance instead of showing an empty list. (#632)
+* Add a first-run prompt on the Documents screen that points new users (and Live Preview visitors) to add their first document, replacing the blank empty-state table. (#632)
+* Occasionally invite established users to leave a WordPress.org review — shown only after real, successful use, dismissible, and never repeated once dismissed. (#632)
+* Documentation: block editor (Gutenberg) support is now described as supported and opt-in rather than experimental, and the readme leads with the plugin's full-text search and AI-generated revision summary capabilities. (#632)
 
 ### 5.2.0
 

--- a/docs/header.md
+++ b/docs/header.md
@@ -5,7 +5,7 @@ Tags: documents, document management, version control, collaboration, revisions
 Requires at least: 5.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 5.2.0
+Stable tag: 5.3.0
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: documents, document management, version control, collaboration, revisions
 Requires at least: 5.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 5.2.0
+Stable tag: 5.3.0
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -230,10 +230,10 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 
 = 5.3.0 =
 
-* The WordPress.org "Live Preview" now opens with sample documents that already carry revision history and workflow states, so the preview demonstrates version control and workflow at a glance instead of showing an empty list.
-* Add a first-run prompt on the Documents screen that points new users (and Live Preview visitors) to add their first document, replacing the blank empty-state table.
-* Occasionally invite established users to leave a WordPress.org review — shown only after real, successful use, dismissible, and never repeated once dismissed.
-* Documentation: block editor (Gutenberg) support is now described as supported and opt-in rather than experimental, and the readme leads with the plugin's full-text search and AI-generated revision summary capabilities.
+* The WordPress.org "Live Preview" now opens with sample documents that already carry revision history and workflow states, so the preview demonstrates version control and workflow at a glance instead of showing an empty list. (#632)
+* Add a first-run prompt on the Documents screen that points new users (and Live Preview visitors) to add their first document, replacing the blank empty-state table. (#632)
+* Occasionally invite established users to leave a WordPress.org review — shown only after real, successful use, dismissible, and never repeated once dismissed. (#632)
+* Documentation: block editor (Gutenberg) support is now described as supported and opt-in rather than experimental, and the readme leads with the plugin's full-text search and AI-generated revision summary capabilities. (#632)
 
 = 5.2.0 =
 

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Document Revisions
 Plugin URI: http://ben.balter.com/2011/08/29/wp-document-revisions-document-management-version-control-wordpress/
 Description: A document management and version control plugin for WordPress that allows teams of any size to collaboratively edit files and manage their workflow.
-Version: 5.2.0
+Version: 5.3.0
 Requires at least: 5.9
 Requires PHP: 8.0
 Author: Ben Balter
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  *  @copyright 2011-2026
  *  @license GPL-3.0-or-later
- *  @version 5.2.0
+ *  @version 5.3.0
  *  @package WP_Document_Revisions
  *  @author Ben Balter <ben@balter.com>
  */
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // parsed by WordPress from the file header itself and must remain literal; this
 // constant is the canonical value for runtime PHP code (cache busters, etc.).
 if ( ! defined( 'WPDR_VERSION' ) ) {
-	define( 'WPDR_VERSION', '5.2.0' );
+	define( 'WPDR_VERSION', '5.3.0' );
 }
 
 // Composer autoloader for production dependencies.


### PR DESCRIPTION
Prepares the 5.3.0 release, shipping the adoption changes merged in #632 (Live Preview seed, first-run onboarding CTA, engagement-gated review nudge, readme repositioning, block-editor docs).

Per the release process:

- **Version bump** in `wp-document-revisions.php` — all three spots (`Version:` header, `@version` docblock, `WPDR_VERSION` constant) → 5.3.0.
- **Stable tag** in `docs/header.md` → 5.3.0.
- **Changelog** — added `(#632)` references to the 5.3.0 entries.
- **Rebuilt `readme.txt`** via `ruby script/build-readme` (stable tag + rolling 3-version changelog window).

Left alone (auto-handled / unmanaged): `languages/*.pot` and script-translation JSON (pot.yml / deploy.yml), `package.json` version, and `src/blocks/*/block.json` versions.

**Not a ship:** merging this to main does not deploy. WordPress.org deploy runs on git **tag** push only — cut and push the `5.3.0` tag after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)