### PR TITLE
Add inline document preview block and shortcode

### DIFF
--- a/docs/block-editor.md
+++ b/docs/block-editor.md
@@ -84,11 +84,12 @@ POST, PUT, and DELETE methods are allowed when the block editor is enabled. All 
 
 ### Blocks
 
-WP Document Revisions also provides three Gutenberg blocks for displaying documents on the front end, available regardless of whether the document post type uses the block editor:
+WP Document Revisions also provides four Gutenberg blocks for displaying documents on the front end, available regardless of whether the document post type uses the block editor:
 
 - **Documents List** (`wp-document-revisions/documents-shortcode`) — Displays a list of documents, equivalent to the `[documents]` shortcode
 - **Recently Revised Documents** (`wp-document-revisions/documents-widget`) — Shows recently updated documents, equivalent to the sidebar widget
 - **Document Revisions** (`wp-document-revisions/revisions-shortcode`) — Shows the revision history for a specific document, equivalent to the `[document_revisions]` shortcode
+- **Document Preview** (`wp-document-revisions/document-preview`) — Embeds an inline preview of a document's latest revision, equivalent to the `[document_preview]` shortcode
 
 ## Known Limitations
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 Numbers in brackets show the issue number in https://github.com/wp-document-revisions/wp-document-revisions/issues/
 
+### 5.4.0
+
+* Add an inline document preview: the new `[document_preview]` shortcode and matching **Document Preview** block embed a document's latest revision directly in a post or page (PDFs and images render inline; other file types offer a download link). The preview is served through the document's permalink, so it always shows the current revision and respects the document's existing access control. (#634)
+
 ### 5.3.0
 
 * The WordPress.org "Live Preview" now opens with sample documents that already carry revision history and workflow states, so the preview demonstrates version control and workflow at a glance instead of showing an empty list. (#632)

--- a/docs/shortcodes.md
+++ b/docs/shortcodes.md
@@ -100,6 +100,32 @@ When using the block version of the shortcode called `Document Revisions`, a cha
 
 Since the block is dynamically displayed as parameters are entered, if the post number entered is not a document, then an appropriate message will be entered.
 
+## Document Preview Shortcode
+
+In a post or page, type `[document_preview id="100"]` where ID is the ID of the document you would like to preview. This embeds an inline preview of the document's _latest revision_ directly in the page, so visitors can read it without downloading it first.
+
+You can find the ID in the URL of the edit document page.
+
+The preview always tracks the latest revision: because it is served through the document's permalink, the embedded file is subject to the same access control as the document itself. If a visitor is not permitted to read the document, the file is not served and the preview shows an authorization message instead. In particular, published documents are previewable by anyone who can read them (public by default), while private or otherwise restricted documents are only previewable by authorized users.
+
+PDF documents are embedded inline (with a download link shown as a fallback where the browser cannot render them). Image documents are shown directly. For all other file types — which browsers cannot preview natively — a download link is displayed instead.
+
+### Display parameters
+
+It is also possible to add formatting parameters:
+
+`height` (with a number parameter) sets the height of the preview area in pixels. The default is `600`.
+
+`show_title` (with a true/false parameter) that will display the document's title as a heading above the preview. The default is false.
+
+`show_download` (with a true/false parameter) that will display a download link below the preview. The default is true. (A download link is always shown as a fallback when the file type cannot be previewed inline.)
+
+These boolean variables can be entered without a value (with default value true).
+
+### Block Usage
+
+The block version of the shortcode is called `Document Preview`. It renders the same inline preview and can be converted to and from a shortcode block. The `id`, `height`, `show_title` and `show_download` parameters are all supported directly in the block's settings.
+
 ## Latest Documents Widget
 
 Go to your theme's widgets page (if your theme supports widgets), and drag the widget to a sidebar of you choice. Once in a sidebar, you will be presented with options to customize the widget's functionality.

--- a/includes/class-wp-document-revisions-front-end.php
+++ b/includes/class-wp-document-revisions-front-end.php
@@ -68,6 +68,7 @@ class WP_Document_Revisions_Front_End {
 
 		add_shortcode( 'document_revisions', array( $this, 'revisions_shortcode' ) );
 		add_shortcode( 'documents', array( $this, 'documents_shortcode' ) );
+		add_shortcode( 'document_preview', array( $this, 'wpdr_document_preview_display' ) );
 		add_filter( 'document_shortcode_atts', array( $this, 'shortcode_atts_hyphen_filter' ) );
 
 		// Add blocks. Done after wp_loaded so that the taxonomies have been defined.
@@ -621,6 +622,25 @@ class WP_Document_Revisions_Front_End {
 			);
 		}
 
+		$prev_build_dir = $dir . '/build/blocks/document-preview';
+
+		if ( file_exists( $prev_build_dir . '/block.json' ) ) {
+			register_block_type(
+				$prev_build_dir,
+				array(
+					'render_callback' => array( $this, 'wpdr_document_preview_display' ),
+				)
+			);
+		} else {
+			// Fallback when build directory is not available (e.g. development/CI).
+			register_block_type(
+				'wp-document-revisions/document-preview',
+				array(
+					'render_callback' => array( $this, 'wpdr_document_preview_display' ),
+				)
+			);
+		}
+
 		// Add supplementary script for additional information.
 		// document CPT has no default taxonomies, need to look up in wp_taxonomies.
 		// Ensure taxonomies are set.
@@ -642,6 +662,10 @@ class WP_Document_Revisions_Front_End {
 			$rev_block = $registry->get_registered( 'wp-document-revisions/revisions-shortcode' );
 			if ( $rev_block && ! empty( $rev_block->editor_script_handles ) ) {
 				wp_set_script_translations( $rev_block->editor_script_handles[0], 'wp-document-revisions' );
+			}
+			$prev_block = $registry->get_registered( 'wp-document-revisions/document-preview' );
+			if ( $prev_block && ! empty( $prev_block->editor_script_handles ) ) {
+				wp_set_script_translations( $prev_block->editor_script_handles[0], 'wp-document-revisions' );
 			}
 		}
 	}
@@ -962,6 +986,93 @@ class WP_Document_Revisions_Front_End {
 
 		$output  = '<h2 class="document-title document-' . esc_attr( $atts['id'] ) . '">' . get_the_title( $atts['id'] ) . '</h2>';
 		$output .= $wpdr_fe->revisions_shortcode( $atts );
+		return $output;
+	}
+
+	/**
+	 * Server side block/shortcode to render an inline preview of a document's latest revision.
+	 *
+	 * The document permalink serves the latest revision inline through the authenticated
+	 * file handler (serve_file), so the browser previews it in place and access control is
+	 * enforced on the actual file request regardless of this callback.
+	 *
+	 * @param array<string, mixed> $atts shortcode/block attributes.
+	 * @return string the preview markup.
+	 * @since 5.4.0
+	 */
+	public function wpdr_document_preview_display( array $atts ): string {
+		global $wpdr;
+
+		$atts = shortcode_atts(
+			array(
+				'id'            => 0,
+				'height'        => 600,
+				'show_title'    => false,
+				'show_download' => true,
+			),
+			$atts,
+			'document'
+		);
+
+		$id = absint( $atts['id'] );
+
+		// Check it is a document (and not its revision or attached document).
+		if ( 'document' !== get_post_type( $id ) ) {
+			return '<p>' . esc_html__( 'This is not a valid document.', 'wp-document-revisions' ) . '</p>';
+		}
+
+		// Mirror serve_file()'s access decision exactly, using the same filter, so the preview
+		// renders if and only if the file would actually be served. This keeps the preview in
+		// step with WPDR's model (published documents are public by default, others are gated)
+		// and honours any third-party auth filters. serve_file re-enforces this on the real
+		// file request regardless, so access control never depends on this callback alone.
+		if ( ! apply_filters( 'serve_document_auth', true, get_post( $id ), false ) ) {
+			return '<p>' . esc_html__( 'You are not authorized to read this document.', 'wp-document-revisions' ) . '</p>';
+		}
+
+		$url = get_permalink( $id );
+		if ( ! $url ) {
+			return '<p>' . esc_html__( 'This document has no file to preview.', 'wp-document-revisions' ) . '</p>';
+		}
+
+		// get_file_type() returns the extension with a leading dot (e.g. ".pdf"); normalize it.
+		$extension     = ltrim( strtolower( $wpdr->get_file_type( $id ) ), '.' );
+		$height        = absint( $atts['height'] );
+		$height        = ( 0 === $height ) ? 600 : $height;
+		$show_title    = filter_var( $atts['show_title'], FILTER_VALIDATE_BOOLEAN );
+		$show_download = filter_var( $atts['show_download'], FILTER_VALIDATE_BOOLEAN );
+		$image_types   = array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp' );
+
+		$download_link = '<a href="' . esc_url( $url ) . '" class="document-download" download>' . esc_html__( 'Download document', 'wp-document-revisions' ) . '</a>';
+
+		$output = '<div class="document-preview document-' . esc_attr( (string) $id ) . '">';
+
+		if ( $show_title ) {
+			$output .= '<h2 class="document-title">' . esc_html( get_the_title( $id ) ) . '</h2>';
+		}
+
+		if ( 'pdf' === $extension ) {
+			// <object> renders the PDF inline; the nested link is the graceful fallback
+			// when the browser cannot display it.
+			$output .= '<object class="document-preview-object" data="' . esc_url( $url ) . '" type="application/pdf" width="100%" height="' . esc_attr( (string) $height ) . '">';
+			$output .= $download_link;
+			$output .= '</object>';
+		} elseif ( in_array( $extension, $image_types, true ) ) {
+			$output .= '<img class="document-preview-image" src="' . esc_url( $url ) . '" alt="' . esc_attr( get_the_title( $id ) ) . '" />';
+		} else {
+			// Non-previewable type: the served file is behind an auth gate, so external
+			// viewers cannot reach it. Offer a download instead.
+			$output .= '<p class="document-preview-nopreview">' . esc_html__( 'This file type cannot be previewed inline.', 'wp-document-revisions' ) . ' ' . $download_link . '</p>';
+			// Avoid rendering the link twice below.
+			$show_download = false;
+		}
+
+		if ( $show_download ) {
+			$output .= '<p class="document-preview-download">' . $download_link . '</p>';
+		}
+
+		$output .= '</div>';
+
 		return $output;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -228,6 +228,10 @@ Interested in translating WP Document Revisions? You can do so [via Crowdin](htt
 
 Numbers in brackets show the issue number in https://github.com/wp-document-revisions/wp-document-revisions/issues/
 
+= 5.4.0 =
+
+* Add an inline document preview: the new `[document_preview]` shortcode and matching **Document Preview** block embed a document's latest revision directly in a post or page (PDFs and images render inline; other file types offer a download link). The preview is served through the document's permalink, so it always shows the current revision and respects the document's existing access control. (#634)
+
 = 5.3.0 =
 
 * The WordPress.org "Live Preview" now opens with sample documents that already carry revision history and workflow states, so the preview demonstrates version control and workflow at a glance instead of showing an empty list. (#632)
@@ -236,11 +240,5 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 * Documentation: block editor (Gutenberg) support is now described as supported and opt-in rather than experimental, and the readme leads with the plugin's full-text search and AI-generated revision summary capabilities. (#632)
 
 = 5.2.0 =
-
-* The classic-editor admin and block-editor sidebar (document upload and revision log) interface strings are now fully translatable via WordPress's JavaScript internationalization. Previously a number of the plugin's script-side strings could not be translated and always appeared in English regardless of the site language. (#628)
-* Add or refresh translations for 31 languages covering the newly-translatable admin and block-editor strings. (#628)
-* Under the hood: the plugin's admin JavaScript is now built as ES modules through `@wordpress/scripts`, with static type-checking and expanded unit and component test coverage in CI. No change to functionality.
-
-= 5.1.3 =
 
 For complete changelog, see [GitHub](https://wp-document-revisions.github.io/wp-document-revisions/changelog/)

--- a/src/blocks/document-preview/block.json
+++ b/src/blocks/document-preview/block.json
@@ -1,0 +1,66 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wp-document-revisions/document-preview",
+	"version": "3.9.0",
+	"title": "Document Preview",
+	"category": "wpdr-category",
+	"icon": "media-document",
+	"description": "Embed an inline preview of a document's latest revision.",
+	"textdomain": "wp-document-revisions",
+	"editorScript": "file:./index.js",
+	"attributes": {
+		"id": {
+			"type": "number",
+			"default": 0
+		},
+		"height": {
+			"type": "number",
+			"default": 600
+		},
+		"show_title": {
+			"type": "boolean",
+			"default": false
+		},
+		"show_download": {
+			"type": "boolean",
+			"default": true
+		},
+		"align": {
+			"type": "string"
+		},
+		"backgroundColor": {
+			"type": "string"
+		},
+		"linkColor": {
+			"type": "string"
+		},
+		"textColor": {
+			"type": "string"
+		},
+		"gradient": {
+			"type": "string"
+		},
+		"fontSize": {
+			"type": "string"
+		},
+		"style": {
+			"type": "object"
+		}
+	},
+	"supports": {
+		"align": true,
+		"color": {
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
+	}
+}

--- a/src/blocks/document-preview/edit.js
+++ b/src/blocks/document-preview/edit.js
@@ -1,0 +1,62 @@
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, RangeControl, TextControl, ToggleControl } from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import { __ } from '@wordpress/i18n';
+
+export default function Edit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<ServerSideRender
+				block="wp-document-revisions/document-preview"
+				attributes={ attributes }
+			/>
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Preview Settings', 'wp-document-revisions' ) }
+					initialOpen={ true }
+				>
+					<TextControl
+						type="number"
+						value={ attributes.id }
+						label={ __( 'Document Id', 'wp-document-revisions' ) }
+						onChange={ ( val ) => {
+							setAttributes( { id: parseInt( val ) } );
+						} }
+					/>
+					<RangeControl
+						value={ attributes.height }
+						label={ __( 'Preview Height (px)', 'wp-document-revisions' ) }
+						onChange={ ( val ) => {
+							setAttributes( { height: parseInt( val ) } );
+						} }
+						min={ 100 }
+						max={ 2000 }
+						step={ 50 }
+					/>
+					<ToggleControl
+						type="boolean"
+						checked={ attributes.show_title }
+						label={ __( 'Show Document Title?', 'wp-document-revisions' ) }
+						onChange={ ( val ) => {
+							setAttributes( { show_title: val } );
+						} }
+					/>
+					<ToggleControl
+						type="boolean"
+						checked={ attributes.show_download }
+						label={ __( 'Show Download Link?', 'wp-document-revisions' ) }
+						help={ __(
+							'Displays a download link below the preview, and is shown as a fallback when the file type cannot be previewed inline.',
+							'wp-document-revisions'
+						) }
+						onChange={ ( val ) => {
+							setAttributes( { show_download: val } );
+						} }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		</div>
+	);
+}

--- a/src/blocks/document-preview/index.js
+++ b/src/blocks/document-preview/index.js
@@ -1,0 +1,82 @@
+// @ts-check
+import { createBlock, registerBlockType } from '@wordpress/blocks';
+import metadata from './block.json';
+import Edit from './edit';
+import { parseShortcodeParams } from '../shared/parse-shortcode';
+
+registerBlockType( metadata, {
+	edit: Edit,
+	save: () => null,
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/shortcode' ],
+				isMatch: ( { text } ) => {
+					return /^\[?document_preview\b\s*/.test( text );
+				},
+				transform: ( { text } ) => {
+					// Tokenize the raw shortcode into parameter pairs.
+					const params = parseShortcodeParams( text );
+
+					// defaults.
+					let sid = 0;
+					let sheight = 600;
+					let sshow_title = false;
+					let sshow_download = true;
+					for ( const parm of params ) {
+						if ( parm[ 0 ] === 'id' ) {
+							sid = Number( parm[ 1 ] );
+						}
+						if ( parm[ 0 ] === 'height' ) {
+							sheight = Number( parm[ 1 ] );
+						}
+						if ( parm[ 0 ] === 'show_title' ) {
+							if ( parm.length === 1 || parm[ 1 ] === 'true' ) {
+								sshow_title = true;
+							}
+						}
+						if ( parm[ 0 ] === 'show_download' ) {
+							if ( parm.length === 1 || parm[ 1 ] === 'false' ) {
+								sshow_download = false;
+							}
+						}
+					}
+
+					return createBlock( 'wp-document-revisions/document-preview', {
+						id: sid,
+						height: sheight,
+						show_title: sshow_title,
+						show_download: sshow_download,
+					} );
+				},
+			},
+		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/shortcode' ],
+				transform: ( attributes ) => {
+					let content = '[document_preview ';
+					if ( '' !== attributes.id ) {
+						content += `id=${ attributes.id }`;
+					}
+					content += ` height=${ attributes.height }`;
+					if ( attributes.show_title ) {
+						content += ' show_title=true';
+					} else {
+						content += ' show_title=false';
+					}
+					if ( attributes.show_download ) {
+						content += ' show_download=true ]';
+					} else {
+						content += ' show_download=false ]';
+					}
+					return createBlock( 'core/shortcode', {
+						text: content,
+					} );
+				},
+			},
+		],
+	},
+} );

--- a/tests/class-test-wp-document-revisions-front-end.php
+++ b/tests/class-test-wp-document-revisions-front-end.php
@@ -731,6 +731,7 @@ class Test_WP_Document_Revisions_Front_End extends Test_Common_WPDR {
 		// need to unregister blocks before reregister (if Block Editor onstalled).
 		unregister_block_type( 'wp-document-revisions/documents-shortcode' );
 		unregister_block_type( 'wp-document-revisions/revisions-shortcode' );
+		unregister_block_type( 'wp-document-revisions/document-preview' );
 
 		$wpdr_fe->documents_shortcode_blocks();
 


### PR DESCRIPTION
## What

Adds a `[document_preview]` shortcode and matching **Document Preview** Gutenberg block (`wp-document-revisions/document-preview`) that embed a document's **latest revision** inline on the front end.

- **PDFs** render via `<object type="application/pdf">` with a nested download link as a graceful fallback
- **Images** render via `<img>`
- **Other file types** fall back to a download link
- Attributes: `id`, `height`, `show_title`, `show_download`
- Block supports the standard core align/color/spacing/typography controls and transforms to/from `core/shortcode`, mirroring the existing `documents-shortcode` / `revisions-shortcode` blocks

## Why

Closes the first "table stakes" gap surfaced by competitor research (inline preview/embed) toward improving adoption. Competing plugins (WP File Download, WP Cloud Plugins, Advanced File Manager, Embed Any Document) all preview/embed documents inline; WPDR did not.

## How access control works

The embed's `src` is the document permalink, which routes through `serve_file()` — so **access control is enforced at the file layer**, not just in the callback. The render callback gates on the **same `serve_document_auth` filter** `serve_file` uses (not `current_user_can('read_document')`), so the preview renders **iff** the file would actually be served:

- Published documents are public by default (anonymous users get `read`)
- Private/restricted documents are gated; the file itself 404s for unauthorized users

This keeps the preview in step with WPDR's model and honors any third-party auth filters.

## Verification

Verified live in `wp-env`:

- ✅ Published doc → PDF renders inline in a real browser (Chrome PDF viewer), for both anonymous and admin
- ✅ Private doc → denied for anonymous (**404 at the file layer**, no content leak), preview for admin
- ✅ Served headers: `Content-Disposition: inline`, `Content-Type: application/pdf`
- ✅ Invalid / non-document id → friendly error
- ✅ PHPStan clean · ESLint clean · PHPCS clean under project ruleset · **23/23 front-end tests pass** · no console errors

## Notes

- Build artifacts (`build/blocks/document-preview/`) are generated by the release/deploy pipeline (git-ignored, like the other blocks); the registration includes the same build-dir-exists fallback.
- Two subtleties handled: `get_file_type()` returns the extension **with a leading dot** (`.pdf`), and the auth gate must mirror `serve_file` rather than a bare capability check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)