### PR TITLE
Fix WordPress 7.0 / PHP 8.1 CI: get_attached_file TypeError + WPCS CVE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	"require-dev": {
 		"phpcsstandards/phpcsutils": "^1.1",
 		"phpcsstandards/phpcsextra": "^1.4",
-		"wp-coding-standards/wpcs": "~3.2",
+		"wp-coding-standards/wpcs": "^3.4.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 		"yoast/phpunit-polyfills": "*",
 		"phpcompatibility/php-compatibility": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "730b86bf7bafdbac5320d3ebb15823ac",
+    "content-hash": "0cac914a8eff3f1050412943a315cab1",
     "packages": [
         {
             "name": "phpoffice/math",
@@ -972,21 +972,21 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "b598aa890815b8df16363271b659d73280129101"
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
-                "reference": "b598aa890815b8df16363271b659d73280129101",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/39467533fdb742446d68c1d10ac33d625ee0311c",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.2.0",
+                "phpcsstandards/phpcsutils": "^1.2.3",
                 "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
@@ -1050,20 +1050,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-12T23:06:57+00:00"
+            "time": "2026-07-27T11:13:17+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -1143,7 +1143,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -2828,16 +2828,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.4.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab"
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
-                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
                 "shasum": ""
             },
             "require": {
@@ -2846,8 +2846,8 @@
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
                 "php": ">=7.2",
-                "phpcsstandards/phpcsextra": "^1.5.0",
-                "phpcsstandards/phpcsutils": "^1.2.2",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
                 "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
@@ -2890,7 +2890,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-07-16T13:05:29+00:00"
+            "time": "2026-07-27T11:53:23+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 
 * Add an inline document preview: the new `[document_preview]` shortcode and matching **Document Preview** block embed a document's latest revision directly in a post or page (PDFs and images render inline; other file types offer a download link). The preview is served through the document's permalink, so it always shows the current revision and respects the document's existing access control. (#634)
 * Add opt-in email notifications (Settings → Media) that alert a configurable recipient list, plus the document's author, when a document changes workflow state or gains a new revision. Disabled by default; the person making the change is never notified of their own change; fully customizable via filters. Supersedes the former code-cookbook recipe by making state-change notifications a built-in feature.
+* Fix a fatal `TypeError` when serving or resolving a document's attached file on newer WordPress: the `get_attached_file` filter now accepts the attachment ID as either an integer or a numeric string (WordPress core passes a string in some paths), casting it internally. Previously the strict `int` type hint could abort the request.
 
 ### 5.3.0
 

--- a/includes/trait-wp-document-revisions-file-handler.php
+++ b/includes/trait-wp-document-revisions-file-handler.php
@@ -947,10 +947,12 @@ trait WP_Document_Revisions_File_Handler {
 	 *
 	 * @since 3.5.0
 	 * @param string|false $file          The file path to where the attached file should be.
-	 * @param int          $attachment_id Attachment Id.
+	 * @param int|string   $attachment_id Attachment Id. WordPress core may pass a numeric string.
 	 * @return string path to document
 	 */
-	public function get_attached_file_filter( $file, int $attachment_id ) {
+	public function get_attached_file_filter( $file, $attachment_id ) {
+		$attachment_id = (int) $attachment_id;
+
 		// returned false.
 		if ( ! $file ) {
 			return $file;

--- a/readme.txt
+++ b/readme.txt
@@ -297,6 +297,7 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 
 * Add an inline document preview: the new `[document_preview]` shortcode and matching **Document Preview** block embed a document's latest revision directly in a post or page (PDFs and images render inline; other file types offer a download link). The preview is served through the document's permalink, so it always shows the current revision and respects the document's existing access control. (#634)
 * Add opt-in email notifications (Settings → Media) that alert a configurable recipient list, plus the document's author, when a document changes workflow state or gains a new revision. Disabled by default; the person making the change is never notified of their own change; fully customizable via filters. Supersedes the former code-cookbook recipe by making state-change notifications a built-in feature.
+* Fix a fatal `TypeError` when serving or resolving a document's attached file on newer WordPress: the `get_attached_file` filter now accepts the attachment ID as either an integer or a numeric string (WordPress core passes a string in some paths), casting it internally. Previously the strict `int` type hint could abort the request.
 
 = 5.3.0 =
 


### PR DESCRIPTION
## Why

`main` is currently **red against WordPress 7.0.2** (and on every open PR), for two unrelated, pre-existing reasons. This PR fixes both so CI goes green again. Neither is related to any feature work — both reproduce on `main` at `origin/main`.

## 1. `get_attached_file` filter TypeError (fatal on WP 7.0 / PHP 8.1)

WordPress core passes the attachment ID to the `get_attached_file` filter as a **numeric string** in some code paths. The callback's strict `int $attachment_id` hint (added in 65a8d93) then threw:

```
TypeError: WP_Document_Revisions::get_attached_file_filter(): Argument #2 ($attachment_id)
must be of type int, string given, called in .../class-wp-hook.php
```

That fatal aborted document file resolution and **cascaded into ~30 downstream test failures** (revision-count mismatches, `file "" exists`, etc. — all artifacts of the aborted request, not real behavior changes). Fix: accept `int|string` and cast to `int` internally.

**Verification:** full PHPUnit suite green **single-site and multisite** on WP 7.0.2 / PHP 8.1 — `OK (415 tests, 3640 assertions)`. Before this change: 5 errors + 30 failures; after: 0.

## 2. WPCS CVE-2026-45293 (dependency audit)

`wp-coding-standards/wpcs` `< 3.4.1` has a high-severity arbitrary-code-execution advisory, failing the `composer audit` CI job. Bump the constraint `~3.2 → ^3.4.1` and refresh the lock (also pulls phpcsutils 1.2.3 / phpcsextra 1.5.1, required by wpcs 3.4.1). Dev-only dependency; no runtime impact. `composer audit` now reports no advisories.

## Scope

Deliberately minimal and surgical — one type-hint relaxation + a dependency bump. No feature or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)