### PR TITLE
Release 5.4.0

### DIFF
--- a/docs/header.md
+++ b/docs/header.md
@@ -5,7 +5,7 @@ Tags: documents, document management, version control, collaboration, revisions
 Requires at least: 5.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 5.3.0
+Stable tag: 5.4.0
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: documents, document management, version control, collaboration, revisions
 Requires at least: 5.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 5.3.0
+Stable tag: 5.4.0
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Document Revisions
 Plugin URI: http://ben.balter.com/2011/08/29/wp-document-revisions-document-management-version-control-wordpress/
 Description: A document management and version control plugin for WordPress that allows teams of any size to collaboratively edit files and manage their workflow.
-Version: 5.3.0
+Version: 5.4.0
 Requires at least: 5.9
 Requires PHP: 8.0
 Author: Ben Balter
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  *  @copyright 2011-2026
  *  @license GPL-3.0-or-later
- *  @version 5.3.0
+ *  @version 5.4.0
  *  @package WP_Document_Revisions
  *  @author Ben Balter <ben@balter.com>
  */
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // parsed by WordPress from the file header itself and must remain literal; this
 // constant is the canonical value for runtime PHP code (cache busters, etc.).
 if ( ! defined( 'WPDR_VERSION' ) ) {
-	define( 'WPDR_VERSION', '5.3.0' );
+	define( 'WPDR_VERSION', '5.4.0' );
 }
 
 // Composer autoloader for production dependencies.


### PR DESCRIPTION
Version bump for the **5.4.0** release: `Version:` header, `@version` docblock, `WPDR_VERSION` constant, `Stable tag`, and regenerated `readme.txt`. Changelog was populated by the merged feature/fix PRs.

## User-facing highlights

- **Inline document preview** — `[document_preview]` shortcode + **Document Preview** block embed a document's latest revision (PDFs/images render inline; others get a download link), respecting existing access control. (#634)
- **Opt-in email notifications** (Settings → Media) on workflow-state change or new revision; off by default, filter-customizable.
- **WordPress 7.0 compatibility fix** — resolves a fatal `TypeError` when serving/resolving a document's attached file. Recommended upgrade for anyone on WP 7.0.
- **Abilities API fixed on WP 6.9+** and its three read-only abilities now exposed to AI agents over MCP via the WordPress MCP Adapter (read-only, permission-gated).

## Shipping

Merging this does **not** deploy. The WordPress.org deploy runs on the `v5.4.0` **git tag push** (`deploy.yml`). After this merges and CI is green, tag `v5.4.0` on `main` to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)