### PR TITLE
Release 5.4.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 Numbers in brackets show the issue number in https://github.com/wp-document-revisions/wp-document-revisions/issues/
 
+### 5.4.1
+
+* Fix a number of broken strings in the bundled translations where a malformed HTML tag or placeholder could cause markup to render as visible text — for example a stray space splitting a `<code>`/`<strong>` tag or sitting inside a link's URL, and a mismatched format placeholder. Also fill the remaining untranslated strings across several locales. (#647)
+
 ### 5.4.0
 
 * Add an inline document preview: the new `[document_preview]` shortcode and matching **Document Preview** block embed a document's latest revision directly in a post or page (PDFs and images render inline; other file types offer a download link). The preview is served through the document's permalink, so it always shows the current revision and respects the document's existing access control. (#634)

--- a/docs/header.md
+++ b/docs/header.md
@@ -5,7 +5,7 @@ Tags: documents, document management, version control, collaboration, revisions
 Requires at least: 5.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 5.4.0
+Stable tag: 5.4.1
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: documents, document management, version control, collaboration, revisions
 Requires at least: 5.9
 Tested up to: 7.0
 Requires PHP: 8.0
-Stable tag: 5.4.0
+Stable tag: 5.4.1
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -293,6 +293,10 @@ Interested in translating WP Document Revisions? You can do so [via Crowdin](htt
 
 Numbers in brackets show the issue number in https://github.com/wp-document-revisions/wp-document-revisions/issues/
 
+= 5.4.1 =
+
+* Fix a number of broken strings in the bundled translations where a malformed HTML tag or placeholder could cause markup to render as visible text — for example a stray space splitting a `<code>`/`<strong>` tag or sitting inside a link's URL, and a mismatched format placeholder. Also fill the remaining untranslated strings across several locales. (#647)
+
 = 5.4.0 =
 
 * Add an inline document preview: the new `[document_preview]` shortcode and matching **Document Preview** block embed a document's latest revision directly in a post or page (PDFs and images render inline; other file types offer a download link). The preview is served through the document's permalink, so it always shows the current revision and respects the document's existing access control. (#634)
@@ -302,12 +306,5 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 * Expose the three read-only Abilities API abilities (`check-document-access`, `get-document-info`, `get-document-revisions`) to AI agents over the Model Context Protocol via the WordPress MCP Adapter — no bundled MCP server required. The mutating `override-document-lock` ability is intentionally excluded, keeping the agent-facing surface read-only, and every call continues to enforce per-document read permissions.
 
 = 5.3.0 =
-
-* The WordPress.org "Live Preview" now opens with sample documents that already carry revision history and workflow states, so the preview demonstrates version control and workflow at a glance instead of showing an empty list. (#632)
-* Add a first-run prompt on the Documents screen that points new users (and Live Preview visitors) to add their first document, replacing the blank empty-state table. (#632)
-* Occasionally invite established users to leave a WordPress.org review — shown only after real, successful use, dismissible, and never repeated once dismissed. (#632)
-* Documentation: block editor (Gutenberg) support is now described as supported and opt-in rather than experimental, and the readme leads with the plugin's full-text search and AI-generated revision summary capabilities. (#632)
-
-= 5.2.0 =
 
 For complete changelog, see [GitHub](https://wp-document-revisions.github.io/wp-document-revisions/changelog/)

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Document Revisions
 Plugin URI: http://ben.balter.com/2011/08/29/wp-document-revisions-document-management-version-control-wordpress/
 Description: A document management and version control plugin for WordPress that allows teams of any size to collaboratively edit files and manage their workflow.
-Version: 5.4.0
+Version: 5.4.1
 Requires at least: 5.9
 Requires PHP: 8.0
 Author: Ben Balter
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  *  @copyright 2011-2026
  *  @license GPL-3.0-or-later
- *  @version 5.4.0
+ *  @version 5.4.1
  *  @package WP_Document_Revisions
  *  @author Ben Balter <ben@balter.com>
  */
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // parsed by WordPress from the file header itself and must remain literal; this
 // constant is the canonical value for runtime PHP code (cache busters, etc.).
 if ( ! defined( 'WPDR_VERSION' ) ) {
-	define( 'WPDR_VERSION', '5.4.0' );
+	define( 'WPDR_VERSION', '5.4.1' );
 }
 
 // Composer autoloader for production dependencies.


### PR DESCRIPTION
## Release 5.4.1

Prepares the 5.4.1 release. Patch bump over 5.4.0.

**Version bumped** in the three canonical spots (`Version:` header, `@version`
docblock, `WPDR_VERSION` constant), plus the `Stable tag` in `docs/header.md`.
Changelog entry added and `readme.txt` regenerated via `script/build-readme`
(rolling 3-version window, so 5.2.0 drops out of readme.txt as expected).

### What ships in 5.4.1

* **Translation fixes (#647)** — repaired malformed HTML tags/placeholders in the
  bundled translations (stray spaces splitting `<code>`/`<strong>` tags or inside
  a link URL, a mismatched format placeholder) and filled the remaining
  untranslated strings across several locales. Also adds an Azure OpenAI
  translation engine and QA tooling (dev-only; excluded from the distribution).
* Routine dependency / CI-action updates (phpstan, playwright, @wordpress/scripts,
  actions/setup-node, actions/setup-python) and a refreshed POT.

### Shipping

This "prepare" PR stops before tagging. Deploy to WordPress.org happens on git
tag push (`v5.4.1`) after merge — merging this PR does not deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
